### PR TITLE
SL-703 implement Menu trigger

### DIFF
--- a/src/Flex.tsx
+++ b/src/Flex.tsx
@@ -1,11 +1,12 @@
+import { CSSProperties } from 'react';
 import { Box, IBoxProps } from './Box';
 import { alignItems, flexDirection, flexWrap, justifyContent, styled } from './utils';
 
 export interface IFlexProps extends IBoxProps {
-  items?: 'stretch' | 'center' | 'flex-start' | 'flex-end' | 'baseline' | 'initial' | 'inherit'; // alignItems
-  justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'initial' | 'inherit'; // justifyContent
-  direction?: 'row' | 'row-reverse' | 'column' | 'column-reverse' | 'initial' | 'inherit'; // flexDirection
-  wrap?: 'nowrap' | 'wrap' | 'wrap-reverse' | 'initial' | 'inherit'; // flexWrap
+  items?: CSSProperties['alignItems'];
+  justify?: CSSProperties['justifyContent'];
+  direction?: CSSProperties['flexDirection'];
+  wrap?: CSSProperties['flexWrap'];
 }
 
 export const Flex = styled<IFlexProps, 'div'>(Box as any)(

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -1,42 +1,78 @@
 import * as React from 'react';
 
 import { Box, IBoxProps } from './Box';
-import { Flex } from './Flex';
+import { Flex, IFlexProps } from './Flex';
 import { Icon, IIcon } from './Icon';
+import { styled } from './utils';
 
 // TODO allow dividers in the menu
-// TODO allow custom renderMenu
-// TODO allow custom renderMenuItem
-// TODO allow custom renderTrigger to make this a popup type component
+
+export interface IMenuTriggerProps {
+  children: any;
+}
 
 /**
  * MENU
  */
+declare type RenderMenuItem = (item: IMenuItemProps, index: number, items: IMenuItemProps[]) => any;
+
 export interface IMenuProps {
   menuItems: IMenuItemProps[];
-
-  attributes?: IBoxProps;
+  direction?: IFlexProps['direction'];
+  attributes?: IFlexProps;
+  renderTrigger?: () => any;
+  renderMenuItem?: RenderMenuItem;
+  renderMenu?: (
+    props: IMenuProps & { className: string },
+    menuItems: IMenuItemProps[],
+    renderMenuItem: RenderMenuItem
+  ) => any;
 }
 
-export const Menu = (props: IMenuProps) => {
-  const { menuItems = [], attributes = {} } = props;
+const MenuTrigger = styled<IMenuTriggerProps>((props: IMenuTriggerProps) =>
+  React.cloneElement(props.children, props)
+)``;
+
+const MenuView = (props: IMenuProps & { className: string }) => {
+  const {
+    attributes = null,
+    className,
+    direction = 'column',
+    menuItems = [],
+    renderTrigger,
+    renderMenuItem = (item: IMenuItemProps, index: number) => <MenuItem key={index} {...item} />,
+    renderMenu = () => (
+      <Flex
+        fg="menu.fg"
+        bg="menu.bg"
+        borderColor="menu.border"
+        border="xs"
+        radius="md"
+        direction={direction}
+        {...attributes}
+      >
+        {menuItems.map(renderMenuItem)}
+      </Flex>
+    ),
+  } = props;
 
   return (
-    <Box
-      fg="menu.fg"
-      bg="menu.bg"
-      borderColor="menu.border"
-      border="xs"
-      radius="md"
-      display="inline-block"
-      {...attributes}
-    >
-      {menuItems.map((item: IMenuItemProps, index: number) => (
-        <MenuItem key={index} {...item} />
-      ))}
-    </Box>
+    <Flex className={className} direction={direction}>
+      {renderTrigger && <MenuTrigger>{renderTrigger()}</MenuTrigger>}
+      {renderMenu(props, menuItems, renderMenuItem)}
+    </Flex>
   );
 };
+
+export const Menu = styled<IMenuProps, 'div'>(MenuView as any)`
+  &:hover ${Flex} {
+    display: flex !important;
+  }
+  
+  ${MenuTrigger} + ${Flex} {
+    display: none;
+  }
+`;
 
 /**
  * MENU ITEM

--- a/src/Portal.tsx
+++ b/src/Portal.tsx
@@ -2,7 +2,7 @@ import { PureComponent } from 'react';
 import * as ReactDOM from 'react-dom';
 
 export interface IPortalProps {
-  children: JSX.Element | string | number;
+  children: any;
   className?: string;
 }
 

--- a/src/__stories__/Menu.tsx
+++ b/src/__stories__/Menu.tsx
@@ -1,15 +1,26 @@
+import { omitBy } from 'lodash';
 import * as React from 'react';
 
-import { withKnobs } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import { select, withKnobs } from '@storybook/addon-knobs';
 import { storiesOf } from '@storybook/react';
 
-import { action } from '@storybook/addon-actions';
-import { Menu } from '../Menu';
+import { Flex, Icon, Menu } from '../';
+
+export const menuKnobs = (tabName = 'Menu'): any => {
+  return omitBy(
+    {
+      direction: select('direction', ['row', 'row-reverse', 'column', 'column-reverse'], 'column', tabName),
+    },
+    val => !val
+  );
+};
 
 storiesOf('Menu', module)
   .addDecorator(withKnobs)
   .add('with defaults', () => (
     <Menu
+      {...menuKnobs()}
       menuItems={[
         { onClick: action('onClick'), title: <span>Has onClick</span> },
         { title: 'No onClick' },
@@ -17,9 +28,9 @@ storiesOf('Menu', module)
       ]}
     />
   ))
-
   .add('with icons', () => (
     <Menu
+      {...menuKnobs()}
       menuItems={[
         { onClick: action('onClick'), title: <span>Has onClick</span>, icon: 'marker' },
         { title: 'No onClick', icon: 'image' },
@@ -29,6 +40,7 @@ storiesOf('Menu', module)
   ))
   .add('with icons only', () => (
     <Menu
+      {...menuKnobs()}
       menuItems={[
         { onClick: action('onClick'), icon: 'marker' },
         { icon: 'image' },
@@ -38,6 +50,42 @@ storiesOf('Menu', module)
   ))
   .add('with subtext', () => (
     <Menu
+      {...menuKnobs()}
+      menuItems={[
+        { onClick: action('onClick'), title: <span>Has onClick</span>, subtitle: 'has subtitle', icon: 'marker' },
+        { title: 'No onClick', icon: 'image' },
+        { title: 'Disabled Item', disabled: true, icon: 'times-circle' },
+      ]}
+    />
+  ))
+  .add('with trigger', () => (
+    <Menu
+      {...menuKnobs()}
+      renderTrigger={() => <Icon icon="heading" />}
+      menuItems={[
+        { onClick: action('onClick'), title: <span>Has onClick</span>, subtitle: 'has subtitle', icon: 'marker' },
+        { title: 'No onClick', icon: 'image' },
+        { title: 'Disabled Item', disabled: true, icon: 'times-circle' },
+      ]}
+    />
+  ))
+  .add('with custom renderMenu', () => (
+    <Menu
+      {...menuKnobs()}
+      renderMenu={({ direction }, items, renderMenuItem) => (
+        <Flex direction={direction}>Custom menu {items.map(renderMenuItem)}</Flex>
+      )}
+      menuItems={[
+        { onClick: action('onClick'), title: <span>Has onClick</span>, subtitle: 'has subtitle', icon: 'marker' },
+        { title: 'No onClick', icon: 'image' },
+        { title: 'Disabled Item', disabled: true, icon: 'times-circle' },
+      ]}
+    />
+  ))
+  .add('with custom renderMenuItem', () => (
+    <Menu
+      {...menuKnobs()}
+      renderMenuItem={item => <span>{item.title}</span>}
       menuItems={[
         { onClick: action('onClick'), title: <span>Has onClick</span>, subtitle: 'has subtitle', icon: 'marker' },
         { title: 'No onClick', icon: 'image' },

--- a/src/__tests__/Menu.spec.tsx
+++ b/src/__tests__/Menu.spec.tsx
@@ -4,16 +4,53 @@ import * as React from 'react';
 
 import * as _solidIcons from '@fortawesome/free-solid-svg-icons';
 
-import { Icon, IconLibrary, IThemeInterface, Menu, MenuItem } from '../index';
+import { Icon, IconLibrary, IMenuItemProps, IThemeInterface, Menu, MenuItem } from '../index';
 import { ThemeProvider } from '../utils';
 
 describe('Menu', () => {
   it('renders items', () => {
     const children = <span>test</span>;
 
-    const wrapper = shallow(<Menu menuItems={[{ title: children }, { title: 'second elem' }]} />);
+    const wrapper = mount(<Menu menuItems={[{ title: children }, { title: 'second elem' }]} />);
 
-    expect(wrapper.children().length).toBe(2);
+    expect(wrapper.find(MenuItem)).toHaveLength(2);
+    wrapper.unmount();
+  });
+
+  it('accepts custom renderTrigger', () => {
+    const trigger = <span>test</span>;
+    const renderTrigger = jest.fn(() => trigger);
+
+    const wrapper = mount(<Menu renderTrigger={renderTrigger} menuItems={[]} />);
+
+    expect(renderTrigger).toHaveBeenCalled();
+    expect(wrapper).toHaveText('test');
+    wrapper.unmount();
+  });
+
+  it('accepts custom renderMenu', () => {
+    const renderMenu = jest.fn(() => 'foo');
+    const renderMenuItem = jest.fn();
+    const menuItems = [{ title: 'test' }, { title: 'second elem' }];
+
+    const wrapper = mount(<Menu renderMenu={renderMenu} renderMenuItem={renderMenuItem} menuItems={menuItems} />);
+
+    expect(renderMenu).toHaveBeenCalledWith(expect.any(Object), menuItems, renderMenuItem);
+    expect(wrapper).toHaveText('foo');
+    wrapper.unmount();
+  });
+
+  it('accepts custom renderMenuItem', () => {
+    const renderMenuItem = jest.fn((item: IMenuItemProps) => item.title);
+    const menuItems = [{ title: 'test' }, { title: 'second elem' }];
+
+    const wrapper = mount(<Menu renderMenuItem={renderMenuItem} menuItems={menuItems} />);
+
+    expect(renderMenuItem).toHaveBeenCalledWith(menuItems[0], 0, menuItems);
+    expect(renderMenuItem).toHaveBeenLastCalledWith(menuItems[1], 1, menuItems);
+
+    expect(wrapper).toHaveText(menuItems.map(({ title }) => title).join(''));
+    wrapper.unmount();
   });
 });
 


### PR DESCRIPTION
Some adjustments needed to unblock SL-629.
I decided to implement it in a slightly different way, therefore plain CSS is used here. Such an implementation should be sufficient in most cases and is way more lightweight.
We can always fall back to Popup if needed.