### PR TITLE
fix(code-editor): fail gracefully when cannot highlight code SL-715

### DIFF
--- a/src/CodeEditor.tsx
+++ b/src/CodeEditor.tsx
@@ -147,3 +147,7 @@ export const CodeEditor = styled<ICodeEditorProps>(CodeEditorView as any)`
     }
   }
 `;
+
+CodeEditor.defaultProps = {
+  language: defaultLanguage,
+};

--- a/src/CodeEditor.tsx
+++ b/src/CodeEditor.tsx
@@ -13,6 +13,44 @@ export interface ICodeEditorProps {
   onChange?: (code: string) => any;
 }
 
+const defaultSupport = {
+  css: 'CSS',
+  javascript: 'JavaScript',
+  markup: 'Markup',
+  clike: 'C-like',
+};
+
+const optionalSupport = {
+  // cpp: 'C++',
+  // csharp: 'C#',
+  // go: 'Go',
+  // html: 'HTML',
+  // http: 'HTTP',
+  // java: 'Java',
+  // json: 'JSON',
+  // jsx: 'JSX',
+  // markdown: 'Markdown',
+  // objectivec: 'Objective-C',
+  // perl: 'Perl',
+  // php: 'PHP',
+  // python: 'Python',
+  // ruby: 'Ruby',
+  // scala: 'Scala',
+  // bash: 'Bash',
+  // swift: 'Swift',
+  // yaml: 'YAML',
+};
+
+/**
+ * List of supported languages: https://prismjs.com/#languages-list
+ */
+export const supportedLanguages = {
+  ...defaultSupport,
+  ...optionalSupport,
+};
+
+export const defaultLanguage = 'javascript';
+
 const CodeEditorView = (props: ICodeEditorProps & { className: string }) => {
   const { className, language, onChange = noop, value } = props;
 

--- a/src/CodeEditor.tsx
+++ b/src/CodeEditor.tsx
@@ -49,8 +49,6 @@ export const supportedLanguages = {
   ...optionalSupport,
 };
 
-export const defaultLanguage = 'javascript';
-
 const CodeEditorView = (props: ICodeEditorProps & { className: string }) => {
   const { className, language, onChange = noop, value } = props;
 
@@ -147,7 +145,3 @@ export const CodeEditor = styled<ICodeEditorProps>(CodeEditorView as any)`
     }
   }
 `;
-
-CodeEditor.defaultProps = {
-  language: defaultLanguage,
-};

--- a/src/__stories__/CodeEditor.tsx
+++ b/src/__stories__/CodeEditor.tsx
@@ -6,7 +6,7 @@ import { text } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-import { CodeEditor } from '../CodeEditor';
+import { CodeEditor, defaultLanguage } from '../CodeEditor';
 
 const store = new Store({
   value: 'stoplight.uiKit();',
@@ -14,7 +14,7 @@ const store = new Store({
 
 export const codeEditorKnobs = (tabName = 'Code Editor') => {
   return {
-    language: text('language', 'js', tabName),
+    language: text('language', defaultLanguage, tabName),
     value: text('value', 'const defaultValue = stoplight.io();', tabName),
     style: object('style', { fontSize: '12px' }, tabName),
   };
@@ -22,9 +22,7 @@ export const codeEditorKnobs = (tabName = 'Code Editor') => {
 
 storiesOf('CodeEditor', module)
   .addDecorator(withKnobs)
-  .add('with defaults', () => (
-    <CodeEditor {...codeEditorKnobs()} onChange={action('onChange')} />
-  ))
+  .add('with defaults', () => <CodeEditor {...codeEditorKnobs()} onChange={action('onChange')} />)
   .addDecorator(StateDecorator(store))
   .add('with store', () => (
     <CodeEditor {...codeEditorKnobs()} value={store.get('value')} onChange={(value: string) => store.set({ value })} />

--- a/src/__stories__/CodeEditor.tsx
+++ b/src/__stories__/CodeEditor.tsx
@@ -6,7 +6,7 @@ import { text } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
-import { CodeEditor, defaultLanguage } from '../CodeEditor';
+import { CodeEditor } from '../CodeEditor';
 
 const store = new Store({
   value: 'stoplight.uiKit();',
@@ -14,7 +14,7 @@ const store = new Store({
 
 export const codeEditorKnobs = (tabName = 'Code Editor') => {
   return {
-    language: text('language', defaultLanguage, tabName),
+    language: text('language', 'javascript', tabName),
     value: text('value', 'const defaultValue = stoplight.io();', tabName),
     style: object('style', { fontSize: '12px' }, tabName),
   };

--- a/src/utils/highlightCode.ts
+++ b/src/utils/highlightCode.ts
@@ -1,5 +1,6 @@
 import { highlight, languages } from 'prismjs';
 
 export const highlightCode = (code: string, language: string) => {
-  return highlight(code, languages[language]);
+  const langDef = languages[language];
+  return langDef ? highlight(code, langDef) : code;
 };


### PR DESCRIPTION
[SL-715](https://stoplightio.atlassian.net/browse/SL-715)

**Notes for reviewer**

- `prismjs` loads only a handful of syntax highlighters by default (marked as `defaultLanguages` in the code)
- slate-editor claims to support all other languages but since prismjs does not load them be default, switching to one of them fails with an exception:

![selection_022](https://user-images.githubusercontent.com/29548931/49075874-04f42680-f238-11e8-9be5-5a14744038e0.png)

- my code lists and groups all supported languages but comments them out because they won't load out of the box. we will have to figure out a proper babel configuration to load them (https://github.com/mAAdhaTTah/babel-plugin-prismjs).
