### PR TITLE
SL-1014 fix Autosize input className

### DIFF
--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -10,6 +10,10 @@ import { useTheme } from './theme';
 
 export type InputValue = boolean | number | string | undefined;
 
+const AutosizeWrapper: FunctionComponent<Partial<{ className: string }>> = ({ className, ...props }) => (
+  <AutosizeInput inputClassName={className} {...props} />
+);
+
 export const Input: FunctionComponent<IInput> = props => {
   const { as = 'input', autosize, onChange = noop, type, ...rest } = props;
 
@@ -26,25 +30,20 @@ export const Input: FunctionComponent<IInput> = props => {
   };
 
   if (autosize) {
-    return jsx(Box, {
-      as: AutosizeInput,
-      placeholderIsMinWidth: true,
-      ...rest,
-      value: internalValue,
-      onChange: handleChange,
-      type,
-      css,
-    });
+    return (
+      <Box
+        as={AutosizeWrapper}
+        placeholderIsMinWidth
+        {...rest}
+        value={internalValue}
+        onChange={handleChange}
+        type={type}
+        css={css}
+      />
+    );
   }
 
-  return jsx(Box, {
-    ...rest,
-    as,
-    value: internalValue,
-    onChange: handleChange,
-    type,
-    css,
-  });
+  return <Box {...rest} as={as} value={internalValue} onChange={handleChange} type={type} css={css} />;
 };
 
 export interface IInput extends IInputProps, IBox<HTMLInputElement> {}

--- a/src/__tests__/Box.spec.tsx
+++ b/src/__tests__/Box.spec.tsx
@@ -1,7 +1,7 @@
 /* @jsx jsx */
 
 import { jsx } from '@emotion/core';
-import { shallow, mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import 'jest-enzyme';
 
 import { Box, Image } from '../';

--- a/src/__tests__/Input.spec.tsx
+++ b/src/__tests__/Input.spec.tsx
@@ -1,0 +1,40 @@
+/* @jsx jsx */
+
+import { jsx } from '@emotion/core';
+import { mount } from 'enzyme';
+import 'jest-enzyme';
+import AutosizeInput from 'react-input-autosize';
+
+import { FunctionComponent } from 'react';
+import { IInput } from '../Input';
+import { ITheme } from '../theme';
+
+describe('Input component', () => {
+  let Input: FunctionComponent<IInput>;
+
+  const theme: Partial<ITheme> = {
+    input: {
+      fg: 'black',
+      bg: 'red',
+    },
+  };
+
+  beforeAll(async () => {
+    jest.mock('../theme', () => ({
+      useTheme: jest.fn().mockReturnValue(theme),
+    }));
+
+    ({ Input } = await import('../'));
+  });
+
+  afterAll(() => {
+    jest.unmock('../theme');
+  });
+
+  it('passes className as inputClassName to AutosizeInput component', () => {
+    const wrapper = mount(<Input autosize />);
+
+    expect(wrapper.find(AutosizeInput)).toHaveProp('inputClassName', expect.stringMatching('css-'));
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
AutosizeInput attaches className to its wrapper by default which breaks default styles.
I changed this behavior and a className produced by Emotion is attached to input now.