### PR TITLE
No keys bug

### DIFF
--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -18,6 +18,7 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     borderLeft,
     borderRight,
     borderRadius,
+    borderColor,
     boxShadow,
     cursor,
     display,
@@ -57,6 +58,8 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     maxWidth,
     opacity,
     overflow,
+    overflowX,
+    overflowY,
     textDecoration,
     textDecorationColor,
     textTransform,
@@ -68,8 +71,9 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
   } = props;
 
   /** Add all the supported styles, passing in the relevant props. */
-  const css = [
+  const css: IBoxCSS = [
     ss.borders({ border, borderTop, borderBottom, borderLeft, borderRight }),
+    ss.borderColor({ borderColor }),
     ss.borderRadius({ borderRadius }),
     ss.boxShadow({ boxShadow }),
     ss.space({ m, mt, mb, ml, mr, mx, my, p, pt, pb, pl, pr, px, py }),
@@ -91,7 +95,6 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     ss.minWidth({ minWidth }),
     ss.maxWidth({ maxWidth }),
 
-    ss.overflow({ overflow }),
     ss.position({ position }),
     ss.top({ top }),
     ss.bottom({ bottom }),
@@ -107,10 +110,11 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     sl.textDecoration({ textDecoration, textDecorationColor }),
     sl.cursor({ cursor }),
     sl.visibility({ visibility }),
+    sl.overflow({ overflow, overflowX, overflowY }),
   ];
 
   /** User provided style get pushed on last. */
-  if (style) css.push(style);
+  if (style) css.push(style as IBoxCSS);
 
   return jsx<Partial<IBox<HTMLOrSVGElement>>>(
     as,
@@ -129,6 +133,7 @@ export interface IBox<T extends HTMLOrSVGElement = HTMLDivElement>
     sl.ITextDecorationProps,
     sl.ITextTransformProps,
     sl.IVisibilityProps,
+    sl.IOverflowProps,
     sl.ICursorProps,
     ss.BorderProps,
     ss.BorderTopProps,

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -1,6 +1,6 @@
 /* @jsx jsx */
 
-import { jsx } from '@emotion/core';
+import { Interpolation, jsx } from '@emotion/core';
 import { ComponentClass, CSSProperties, forwardRef, FunctionComponent, HTMLAttributes, ReactHTML } from 'react';
 import * as ss from 'styled-system';
 
@@ -108,7 +108,7 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
   /** User provided style get pushed on last. */
   if (style) css.push(style);
 
-  return jsx<Partial<IBox<HTMLElement>>>(
+  return jsx<Partial<IBox<HTMLOrSVGElement>>>(
     as,
     {
       ...rest,
@@ -118,6 +118,8 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     children
   );
 });
+
+export type IBoxCSS = Interpolation | Interpolation[];
 
 export interface IBox<T extends HTMLOrSVGElement = HTMLDivElement>
   extends HTMLAttributes<T>,
@@ -156,6 +158,6 @@ export interface IBox<T extends HTMLOrSVGElement = HTMLDivElement>
   as?: keyof ReactHTML | FunctionComponent | ComponentClass;
   children?: any;
   style?: CSSProperties;
-  css?: any;
+  css?: IBoxCSS;
   [key: string]: any;
 }

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -19,6 +19,7 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     borderRight,
     borderRadius,
     boxShadow,
+    cursor,
     display,
     fontSize,
     fontWeight,
@@ -62,6 +63,7 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     color,
     backgroundColor,
     transform,
+    visibility,
     ...rest
   } = props;
 
@@ -103,6 +105,8 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
     sl.color({ color, backgroundColor }),
     sl.textTransform({ textTransform }),
     sl.textDecoration({ textDecoration, textDecorationColor }),
+    sl.cursor({ cursor }),
+    sl.visibility({ visibility }),
   ];
 
   /** User provided style get pushed on last. */
@@ -119,12 +123,13 @@ export const Box = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>((props, 
   );
 });
 
-export type IBoxCSS = Interpolation | Interpolation[];
-
 export interface IBox<T extends HTMLOrSVGElement = HTMLDivElement>
   extends HTMLAttributes<T>,
+    sl.IColorProps,
     sl.ITextDecorationProps,
-    sl.IListStyleProps,
+    sl.ITextTransformProps,
+    sl.IVisibilityProps,
+    sl.ICursorProps,
     ss.BorderProps,
     ss.BorderTopProps,
     ss.BorderBottomProps,
@@ -161,3 +166,5 @@ export interface IBox<T extends HTMLOrSVGElement = HTMLDivElement>
   css?: IBoxCSS;
   [key: string]: any;
 }
+
+export type IBoxCSS = Interpolation | Interpolation[];

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -2,105 +2,42 @@
 
 import { jsx } from '@emotion/core';
 import { Omit } from '@stoplight/types';
-import noop = require('lodash/noop');
-import { FunctionComponent, ReactEventHandler, useState } from 'react';
+import { ChangeEventHandler, FunctionComponent, useCallback, useState } from 'react';
 
-import { Box, Flex, IBox, Icon, useTheme } from './';
-
-interface ICheckboxInputProps {
-  id: IBox['id'];
-  onChange: ReactEventHandler<HTMLInputElement>;
-}
-
-interface ICheckboxInput extends ICheckboxInputProps {}
-
-const CheckboxInput: FunctionComponent<ICheckboxInput> = props => {
-  return jsx(Box, {
-    ...props,
-    as: 'input',
-    type: 'checkbox',
-    position: 'absolute',
-    style: {
-      clip: 'rect(1px, 1px, 1px, 1px)',
-    },
-  });
-};
-
-interface ICheckboxInnerProps {
-  isChecked: boolean;
-  isDisabled: boolean;
-  width?: IBox['width'];
-  height?: IBox['height'];
-}
-
-export interface ICheckboxInner extends ICheckboxInnerProps {}
-
-const CheckboxInner: FunctionComponent<ICheckboxInner> = props => {
-  const css = checkboxInnerStyles(props);
-
-  return jsx(
-    Flex,
-    {
-      as: 'span',
-      css,
-    },
-    props.isChecked && [jsx(Icon, { icon: 'check', backgroundColor: 'inherit' })]
-  );
-};
-
-const checkboxInnerStyles = ({ isDisabled, isChecked, height = '20px', width = '20px' }: ICheckboxInner) => {
-  const theme = useTheme();
-
-  return {
-    margin: 0,
-    padding: 0,
-    borderRadius: '5px',
-    backgroundColor: isChecked ? theme.checkbox.checkedBg : theme.checkbox.bg,
-    color: theme.checkbox.fg,
-    cursor: isDisabled ? 'not-allowed' : 'pointer',
-    width,
-    height,
-    opacity: isDisabled ? 0.6 : 1,
-    fontSize: '14px',
-    alignItems: 'center',
-    justifyContent: 'center',
-    transition: 'background-color .15s ease-in-out',
-    overflow: 'hidden',
-  };
-};
+import { Box, Flex, IBox, useTheme } from './';
 
 export const Checkbox: FunctionComponent<ICheckbox> = props => {
-  const { id, disabled: isDisabled, width, height, onChange = noop, ...rest } = props;
-  const css = checkboxStyles();
+  const { id, disabled: isDisabled, onChange, ...rest } = props;
 
   const [checked, setValue] = useState<boolean>(props.checked || false);
   const isChecked = props.hasOwnProperty('checked') ? props.checked : checked;
 
-  const handleChange: ReactEventHandler<HTMLInputElement> = event => {
-    setValue(event.currentTarget.checked);
-    onChange(event.currentTarget.checked);
-  };
+  const css = checkboxStyles({ isDisabled, isChecked });
 
-  return jsx(
-    Box,
-    {
-      ...rest,
-      as: 'label',
-      htmlFor: id,
-      css,
-    },
-    [
-      jsx(CheckboxInput, {
-        id,
-        onChange: handleChange,
-      }),
-      jsx(CheckboxInner, {
-        isChecked,
-        isDisabled,
-        height,
-        width,
-      }),
-    ]
+  const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(({ target }) => {
+    setValue(target.checked);
+    if (onChange !== undefined) {
+      onChange(target.checked);
+    }
+  }, []);
+
+  return (
+    <Flex {...rest} as="label" css={css} htmlFor={id}>
+      <Box
+        as="input"
+        type="checkbox"
+        id={id}
+        onChange={handleChange}
+        position="absolute"
+        css={{ clip: 'rect(1px, 1px, 1px, 1px)' }}
+      />
+      <svg aria-hidden="true" viewBox="0 0 512 512" width="14px" height="14px">
+        <path
+          fill="currentColor"
+          d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+        />
+      </svg>
+    </Flex>
   );
 };
 
@@ -111,6 +48,27 @@ export interface ICheckboxProps {
 
 export interface ICheckbox extends ICheckboxProps, Omit<IBox<HTMLLabelElement>, 'as|onChange'> {}
 
-export const checkboxStyles = () => ({
-  display: 'inline-block',
-});
+export const checkboxStyles = ({ isChecked, isDisabled }: ICheckboxStyles) => {
+  const theme = useTheme();
+
+  return {
+    alignItems: 'center',
+    backgroundColor: isChecked ? theme.checkbox.checkedBg : theme.checkbox.bg,
+    borderRadius: '5px',
+    color: isChecked ? theme.checkbox.fg : theme.checkbox.bg,
+    cursor: isDisabled ? 'not-allowed' : 'pointer',
+    height: '20px',
+    justifyContent: 'center',
+    opacity: isDisabled ? 0.6 : 1,
+    overflow: 'hidden',
+    margin: 0,
+    padding: 0,
+    width: '20px',
+    transition: 'background-color .15s ease-in-out',
+  };
+};
+
+interface ICheckboxStyles {
+  isChecked: boolean;
+  isDisabled: boolean;
+}

--- a/src/List.tsx
+++ b/src/List.tsx
@@ -10,16 +10,12 @@ import * as sl from './styles';
 export const List: FunctionComponent<IList> = props => {
   const { as = 'ul', listStyle, listStylePosition, ...rest } = props;
 
-  const css = [sl.listStyle({ listStyle, listStylePosition })];
+  const css = sl.listStyle({ listStyle, listStylePosition });
 
-  return jsx(Box, {
-    ...rest,
-    css,
-    as,
-  });
+  return <Box {...rest} as={as} css={css} />;
 };
 
-export interface IList extends IListProps, sl.IColorProps, Omit<IBox<HTMLUListElement | HTMLOListElement>, 'as'> {}
+export interface IList extends IListProps, sl.IListStyleProps, Omit<IBox<HTMLUListElement | HTMLOListElement>, 'as'> {}
 
 export interface IListProps {
   as?: 'ul' | 'ol';

--- a/src/Menu.tsx
+++ b/src/Menu.tsx
@@ -4,7 +4,7 @@ import { jsx } from '@emotion/core';
 
 import { FunctionComponent, ReactNode } from 'react';
 
-import { Box } from './Box';
+import { Box, IBoxCSS } from './Box';
 import { Flex, IFlex } from './Flex';
 import { useHover } from './hooks/useHover';
 import { Icon, IIcon } from './Icon';
@@ -167,15 +167,15 @@ export interface IMenuItemProps {
 
 export interface IMenuItem extends IMenuItemProps, Pick<IFlex, Exclude<keyof IFlex, 'title'>> {}
 
-const menuItemStyles = ({ disabled, onClick }: Partial<IMenuItemProps>) => {
+const menuItemStyles = ({ disabled, onClick }: Partial<IMenuItemProps>): IBoxCSS => {
   const theme = useTheme();
 
   return [
     {
       alignItems: 'center',
-      padding: '6px 10px', // @md @lg'
+      padding: '6px 10px',
       cursor: disabled ? 'not-allowed' : onClick ? 'pointer' : 'default',
-      opacity: disabled && 0.6,
+      opacity: disabled ? 0.6 : 1,
 
       ':hover': {
         backgroundColor: theme.menu.hoverBg,

--- a/src/Toggle.tsx
+++ b/src/Toggle.tsx
@@ -2,121 +2,63 @@
 
 import { jsx } from '@emotion/core';
 import { Omit } from '@stoplight/types';
-import noop = require('lodash/noop');
-import { FunctionComponent, ReactEventHandler, SyntheticEvent, useState } from 'react';
+import { ChangeEventHandler, FunctionComponent, useCallback, useState } from 'react';
 
-import { Box, Flex, IBox, useTheme } from './';
-import { Icon } from './Icon';
+import { Box, Flex, IBox, IBoxCSS, useTheme } from './';
 
-interface IToggleInputProps {
-  id?: string;
-  onChange: ReactEventHandler<HTMLInputElement>;
-}
+const ToggleCircle: FunctionComponent<IToggleCircle> = props => {
+  const css = circleStyles(props);
 
-const ToggleInput: FunctionComponent<IToggleInputProps> = props => {
-  return jsx(Box, {
-    ...props,
-    as: 'input',
-    type: 'checkbox',
-    css: {
-      position: 'absolute',
-    },
-    style: {
-      clip: 'rect(1px, 1px, 1px, 1px)',
-    },
-  });
+  return <Box as="span" css={css} />;
 };
 
-interface IToggleInnerProps {
+interface IToggleCircleProps {
   isChecked: boolean;
-  isDisabled: boolean;
-  height?: IBox['height'];
-  width?: IBox['width'];
 }
 
-const ToggleInnerIcon: FunctionComponent<IToggleInnerProps> = props => {
-  const css = toggleInnerIconStyles(props);
+interface IToggleCircle extends IToggleCircleProps {}
 
-  return jsx(Icon, {
-    icon: 'circle',
-    css,
-  });
-};
-
-const toggleInnerIconStyles = ({ isChecked }: IToggleInnerProps) => {
+const circleStyles = ({ isChecked }: IToggleCircleProps) => {
   const theme = useTheme();
 
   return {
-    color: isChecked ? theme.toggle.checkedFg : theme.toggle.checkedBg,
-    paddingLeft: isChecked ? '22px' : '4px',
-    transition: 'padding-left .15s ease-in-out, color .25s ease-in-out',
-  };
-};
-
-const ToggleInner: FunctionComponent<IToggleInnerProps> = props => {
-  const css = toggleInnerStyles(props);
-
-  return jsx(
-    Flex,
-    {
-      as: 'span',
-      css,
-    },
-    [jsx(ToggleInnerIcon, props)]
-  );
-};
-
-const toggleInnerStyles = ({ isDisabled, isChecked, height = '20px', width = '40px' }: IToggleInnerProps) => {
-  const theme = useTheme();
-
-  return {
-    display: 'block',
-    margin: 0,
-    padding: 0,
-    borderRadius: '100px',
-    backgroundColor: isChecked ? theme.toggle.checkedBg : theme.toggle.bg,
-    cursor: isDisabled ? 'not-allowed' : 'pointer',
-    width,
-    height,
-    opacity: isDisabled ? 0.6 : 1,
-    fontSize: '14px',
-    alignItems: 'center',
-    transition: 'background-color .15s ease-in-out',
+    display: 'inline-block',
+    borderRadius: '50%',
+    width: '14px',
+    height: '14px',
+    backgroundColor: isChecked ? theme.toggle.checkedFg : theme.toggle.checkedBg,
+    marginLeft: isChecked ? '22px' : '4px',
+    transition: 'margin-left .15s ease-in-out, background-color .25s ease-in-out',
   };
 };
 
 export const Toggle: FunctionComponent<IToggle> = props => {
-  const { id, disabled, height, width, onChange = noop, ...rest } = props;
-  const css = toggleStyles();
+  const { id, disabled: isDisabled, onChange, ...rest } = props;
 
   const [checked, setValue] = useState<boolean>(props.checked || false);
   const isChecked = props.hasOwnProperty('checked') ? props.checked : checked;
 
-  const handleChange = (event: SyntheticEvent<HTMLInputElement>) => {
-    setValue(event.currentTarget.checked);
-    onChange(event.currentTarget.checked);
-  };
+  const css = toggleStyles({ isDisabled, isChecked });
 
-  return jsx(
-    Box,
-    {
-      ...rest,
-      as: 'label',
-      htmlFor: id,
-      css,
-    },
-    [
-      jsx(ToggleInput, {
-        id,
-        onChange: handleChange,
-      }),
-      jsx(ToggleInner, {
-        isChecked,
-        isDisabled: !!disabled,
-        height,
-        width,
-      }),
-    ]
+  const handleChange = useCallback<ChangeEventHandler<HTMLInputElement>>(({ target }) => {
+    setValue(target.checked);
+    if (onChange !== undefined) {
+      onChange(target.checked);
+    }
+  }, []);
+
+  return (
+    <Flex {...rest} as="label" css={css} htmlFor={id}>
+      <Box
+        as="input"
+        type="checkbox"
+        id={id}
+        onChange={handleChange}
+        position="absolute"
+        css={{ clip: 'rect(1px, 1px, 1px, 1px)' }}
+      />
+      <ToggleCircle isChecked={isChecked} />
+    </Flex>
   );
 };
 
@@ -126,6 +68,25 @@ export interface IToggleProps {
 
 export interface IToggle extends IToggleProps, Omit<IBox<HTMLLabelElement>, 'as|onChange'> {}
 
-const toggleStyles = () => ({
-  display: 'inline-block',
-});
+const toggleStyles = ({ isDisabled, isChecked }: IToggleStyles): IBoxCSS => {
+  const theme = useTheme();
+
+  return {
+    alignItems: 'center',
+    backgroundColor: isChecked ? theme.toggle.checkedBg : theme.toggle.bg,
+    borderRadius: '100px',
+    cursor: isDisabled ? 'not-allowed' : 'pointer',
+    fontSize: '14px',
+    height: '20px',
+    opacity: isDisabled ? 0.6 : 1,
+    padding: 0,
+    margin: 0,
+    width: '40px',
+    transition: 'background-color .15s ease-in-out',
+  };
+};
+
+interface IToggleStyles {
+  isChecked: boolean;
+  isDisabled: boolean;
+}

--- a/src/__stories__/Typography/Text.tsx
+++ b/src/__stories__/Typography/Text.tsx
@@ -14,7 +14,7 @@ export const textKnobs = (tabName = 'Text'): IText => ({
   ...boxKnobs(),
   tracking: select('tracking', LetterSpacing, '', tabName),
   leading: select('leading', LineHeight, '', tabName),
-  casing: select('casing', Casing, '', tabName),
+  casing: select('casing', Casing, '', tabName) as IText['textTransform'],
   textDecoration: select('textDecoration', Decoration, '', tabName),
   textDecorationColor: text('textDecorationColor', 'valid-color', tabName),
   italic: boolean('italic', false, tabName),

--- a/src/__tests__/Checkbox.spec.tsx
+++ b/src/__tests__/Checkbox.spec.tsx
@@ -1,0 +1,67 @@
+import { mount } from 'enzyme';
+import 'jest-enzyme';
+import * as React from 'react';
+
+import { ICheckbox } from '../Checkbox';
+import { ITheme } from '../theme';
+
+describe('Checkbox component', () => {
+  let Checkbox: React.FunctionComponent<ICheckbox>;
+
+  const theme: Partial<ITheme> = {
+    checkbox: {
+      fg: 'blue',
+      bg: 'red',
+      checkedBg: 'green',
+    },
+  };
+
+  beforeAll(async () => {
+    jest.mock('../theme', () => ({
+      useTheme: jest.fn().mockReturnValue(theme),
+    }));
+
+    ({ Checkbox } = await import('../'));
+  });
+
+  afterAll(() => {
+    jest.unmock('../theme');
+  });
+
+  it('passes all custom props', () => {
+    const props = {
+      onBlur: jest.fn(),
+      onFocus: jest.fn(),
+    };
+
+    const wrapper = mount(<Checkbox id="4" {...props} />);
+    expect(wrapper).toHaveProp(props);
+    wrapper.unmount();
+  });
+
+  it('renders svg icon', () => {
+    const wrapper = mount(<Checkbox id="4" />);
+    expect(wrapper.find('svg')).toExist();
+    wrapper.unmount();
+  });
+
+  it('calls onChange handler with given state', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(<Checkbox id="4" onChange={onChange} />);
+    wrapper.find('input').simulate('change', {
+      target: {
+        checked: true,
+      },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        checked: false,
+      },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    wrapper.unmount();
+  });
+});

--- a/src/__tests__/Toggle.spec.tsx
+++ b/src/__tests__/Toggle.spec.tsx
@@ -1,0 +1,64 @@
+import { mount } from 'enzyme';
+import 'jest-enzyme';
+import * as React from 'react';
+
+import { ITheme } from '../theme';
+import { IToggle } from '../Toggle';
+
+describe('Toggle component', () => {
+  let Toggle: React.FunctionComponent<IToggle>;
+
+  const theme: Partial<ITheme> = {
+    toggle: {
+      fg: 'blue',
+      bg: 'red',
+      border: 'green',
+      checkedBg: 'orange',
+      checkedFg: 'black',
+      checkedBorder: 'white',
+    },
+  };
+
+  beforeAll(async () => {
+    jest.mock('../theme', () => ({
+      useTheme: jest.fn().mockReturnValue(theme),
+    }));
+
+    ({ Toggle } = await import('../'));
+  });
+
+  afterAll(() => {
+    jest.unmock('../theme');
+  });
+
+  it('passes all custom props', () => {
+    const props = {
+      onBlur: jest.fn(),
+      onFocus: jest.fn(),
+    };
+
+    const wrapper = mount(<Toggle id="4" {...props} />);
+    expect(wrapper).toHaveProp(props);
+    wrapper.unmount();
+  });
+
+  it('calls onChange handler with given state', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(<Toggle id="4" onChange={onChange} />);
+    wrapper.find('input').simulate('change', {
+      target: {
+        checked: true,
+      },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(true);
+
+    wrapper.find('input').simulate('change', {
+      target: {
+        checked: false,
+      },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(false);
+    wrapper.unmount();
+  });
+});

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,6 +1,7 @@
 import {
   BackgroundColorProperty,
   ColorProperty,
+  CursorProperty,
   FlexFlowProperty,
   ListStylePositionProperty,
   ListStyleProperty,
@@ -8,6 +9,7 @@ import {
   TextDecorationProperty,
   TextTransformProperty,
   TransformProperty,
+  VisibilityProperty,
 } from 'csstype';
 
 export interface IColorProps {
@@ -62,4 +64,20 @@ export interface IFlexFlowProperty {
 
 export const flexFlow = (props: IFlexFlowProperty) => ({
   flexFlow: props.flexFlow,
+});
+
+export interface ICursorProps {
+  cursor?: CursorProperty;
+}
+
+export const cursor = (props: ICursorProps) => ({
+  cursor: props.cursor,
+});
+
+export interface IVisibilityProps {
+  visibility?: VisibilityProperty;
+}
+
+export const visibility = (props: IVisibilityProps) => ({
+  visibility: props.visibility,
 });

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -5,6 +5,9 @@ import {
   FlexFlowProperty,
   ListStylePositionProperty,
   ListStyleProperty,
+  OverflowProperty,
+  OverflowXProperty,
+  OverflowYProperty,
   TextDecorationColorProperty,
   TextDecorationProperty,
   TextTransformProperty,
@@ -81,3 +84,15 @@ export interface IVisibilityProps {
 export const visibility = (props: IVisibilityProps) => ({
   visibility: props.visibility,
 });
+
+export const overflow = (props: IOverflowProps) => ({
+  overflow: props.overflow,
+  overflowX: props.overflowX,
+  overflowY: props.overflowY,
+});
+
+export interface IOverflowProps {
+  overflow?: OverflowProperty;
+  overflowX?: OverflowXProperty;
+  overflowY?: OverflowYProperty;
+}


### PR DESCRIPTION
Toggle and Checkboxes caused React to issue a warning in Studio.
I decided to address one of the issues related to icons we talked about in the past.
Both Toggle and Checkbox are no longer dependant on Icon. 
The appearance is preserved.
Moreover, added proper typing for the CSS prop as well as some simple tests for altered components.
Also, added support for fairly common CSS rules such as cursor and visibility.
