### PR TITLE
feat: add Canvas component [proposal / thought experiment]

### DIFF
--- a/.storybook/custom-addons/withThemes/decorator.tsx
+++ b/.storybook/custom-addons/withThemes/decorator.tsx
@@ -5,7 +5,7 @@ import { jsx } from '@emotion/core';
 import addons, { makeDecorator } from '@storybook/addons';
 import { Component, FunctionComponent, ReactNode } from 'react';
 
-import { createThemedModule, Flex, ICustomTheme, ThemeProvider } from '../../../src';
+import { Canvas, createThemedModule, Flex, ICustomTheme, ThemeProvider } from '../../../src';
 
 interface IAppLayout extends ICustomTheme {
   canvas?: {
@@ -14,7 +14,7 @@ interface IAppLayout extends ICustomTheme {
   };
 }
 
-const { ThemeZone, useTheme } = createThemedModule<'app', IAppLayout>();
+const { ThemeZone } = createThemedModule<'app', IAppLayout>();
 
 export const withThemes = (themes: any[], zones: object) =>
   makeDecorator({
@@ -30,14 +30,8 @@ export const withThemes = (themes: any[], zones: object) =>
   });
 
 const App: FunctionComponent<Partial<{ children: ReactNode }>> = ({ children }) => {
-  const theme = useTheme();
-
   return (
-    <Flex
-      backgroundColor={theme.canvas && theme.canvas.bg}
-      color={theme.canvas && theme.canvas.fg}
-      alignItems="center"
-      justifyContent="center"
+    <Canvas
       position="absolute"
       top={0}
       bottom={0}
@@ -48,21 +42,23 @@ const App: FunctionComponent<Partial<{ children: ReactNode }>> = ({ children }) 
           'system-ui, BlinkMacSystemFont, -apple-system, Segoe UI, Roboto, Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif',
       }}
     >
-      <style
-        dangerouslySetInnerHTML={{
-          __html: `
-            .PreviewContainer td:nth-child(2) {
-              max-width: 460px;
-              overflow: auto;
-            }
-          `,
-        }}
-      />
+      <Flex alignItems="center" justifyContent="center" width="100%" height="100%">
+        <style
+          dangerouslySetInnerHTML={{
+            __html: `
+              .PreviewContainer td:nth-child(2) {
+                max-width: 460px;
+                overflow: auto;
+              }
+            `,
+          }}
+        />
 
-      <Flex overflow="visible" m="auto" p="75px 0" className="PreviewContainer">
-        {children}
+        <Flex overflow="visible" m="auto" p="75px 0" className="PreviewContainer">
+          {children}
+        </Flex>
       </Flex>
-    </Flex>
+    </Canvas>
   );
 };
 

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -1,0 +1,21 @@
+/* @jsx jsx */
+
+import { jsx } from '@emotion/core';
+import { FunctionComponent } from 'react';
+
+import { Box, IBox } from './Box';
+import { useTheme } from './theme';
+
+export interface ICanvas {
+  fg?: string;
+  bg?: string;
+}
+
+export const Canvas: FunctionComponent<ICanvas & IBox> = ({ fg, bg, ...rest }) => {
+  const theme = useTheme();
+  // Note: using this comparison so we can still set fg and bg to empty string.
+  if (fg == null && theme.canvas && theme.canvas.fg) fg = theme.canvas.fg;
+  if (bg == null && theme.canvas && theme.canvas.bg) bg = theme.canvas.bg;
+
+  return <Box {...rest} color={fg} backgroundColor={bg} />;
+};

--- a/src/__stories__/Layout/Canvas.tsx
+++ b/src/__stories__/Layout/Canvas.tsx
@@ -1,0 +1,13 @@
+/* @jsx jsx */
+
+import { jsx } from '@emotion/core';
+import { withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+
+import { Canvas } from '../../Canvas';
+
+storiesOf('Layout:Canvas', module)
+  .addDecorator(withKnobs)
+  .add('with defaults', () => (
+    <Canvas>Canvas is a specialized Box that derives its foreground and background colors from the theme.</Canvas>
+  ));

--- a/src/__stories__/Layout/index.ts
+++ b/src/__stories__/Layout/index.ts
@@ -1,3 +1,4 @@
 import './Box';
 import './Break';
+import './Canvas';
 import './Flex';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './BlockQuote';
 export * from './Box';
 export * from './Break';
 export * from './Button';
+export * from './Canvas';
 export * from './Checkbox';
 export * from './Dialog';
 export * from './Flex';

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -3,6 +3,11 @@ import { ITheme } from './types';
 export const darkTheme: ITheme = {
   base: 'dark',
 
+  canvas: {
+    fg: 'white',
+    bg: '#222',
+  },
+
   button: {
     fg: 'white',
     bg: 'rgba(255, 255, 255, 0.2)',

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -3,6 +3,11 @@ import { ITheme } from './types';
 export const lightTheme: ITheme = {
   base: 'light',
 
+  canvas: {
+    fg: '#111',
+    bg: '#fff',
+  },
+
   button: {
     fg: 'white',
     bg: 'rgba(0, 0, 0, 0.5)',

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -9,6 +9,11 @@ export type BaseTheme = 'dark' | 'light';
 export interface ITheme {
   base: BaseTheme;
 
+  canvas: {
+    fg: string;
+    bg: string;
+  };
+
   checkbox: {
     fg: string;
     bg: string;


### PR DESCRIPTION
I keep running into this "problem" that I don't know where the main background for the theme is set. This is understandable because AFAICT it isn't anywhere, specifically. We have a "canvas" zone in the Studio theme but it's purely abstract.

So this is me thinking, "what if the `canvas` zone wasn't abstract but concrete?" You can see the result in the  `.storybook/custom-addons/withThemes/decorator.tsx` refactoring.

Before, a single `Flex` component was tasked with two concerns: theme colors and layout:
```jsx
const theme = useTheme();

return (
  <Flex
    backgroundColor={theme.canvas && theme.canvas.bg}
    color={theme.canvas && theme.canvas.fg}
    alignItems="center"
    justifyContent="center"
    position="absolute"
    top={0}
    bottom={0}
    left={0}
    right={0}
  >
```

Afterward, the theme colors are set automatically using `<Canvas>` (so the component no longer needs a `useTheme()` hook) and the `<Flex>` just handles layout.

```jsx
return (
  <Canvas
    position="absolute"
    top={0}
    bottom={0}
    left={0}
    right={0}
  >
    <Flex
      alignItems="center"
      justifyContent="center"
      width="100%"
      height="100%"
    >
```

I am thinking about this because examining stoplightio/storybook-config#2 made me feel like we were missing some primitive.

Thoughts? Feelings? Honestly, I've been feeling "off" today, so I'm not sure if I can judge whether this idea as proposed is even good or not, but... lemme know.