### PR TITLE
feat: add invalid variants for Checkbox, Input, Select, and Textarea [SL-1788]

### DIFF
--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -45,7 +45,12 @@ export const Checkbox: FunctionComponent<ICheckbox> = props => {
 export const checkboxStyles = ({ isChecked, isDisabled, invalid }: ICheckboxStyles) => {
   const { checkbox: baseTheme } = useTheme();
 
-  const { invalid: invalidTheme = {} } = baseTheme;
+  const invalidTheme = {
+    fg: baseTheme.invalidFg,
+    bg: baseTheme.invalidBg,
+    border: baseTheme.invalidBorder,
+    checked: baseTheme.invalidChecked,
+  };
 
   const theme = { ...baseTheme };
   if (invalid) Object.assign(theme, invalidTheme);

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -49,7 +49,7 @@ export const checkboxStyles = ({ isChecked, isDisabled, invalid }: ICheckboxStyl
     {
       color: checkbox.bg,
       backgroundColor: checkbox.bg,
-      border: invalid ? `1px solid ${checkbox.invalid}` : checkbox.border ? `1px solid ${checkbox.border}` : 'none',
+      border: invalid ? `1px solid ${checkbox.invalidFg}` : checkbox.border ? `1px solid ${checkbox.border}` : 'none',
 
       height: '14px',
       width: '14px',

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -43,13 +43,18 @@ export const Checkbox: FunctionComponent<ICheckbox> = props => {
 };
 
 export const checkboxStyles = ({ isChecked, isDisabled, invalid }: ICheckboxStyles) => {
-  const { checkbox } = useTheme();
+  const { checkbox: baseTheme } = useTheme();
+
+  const { invalid: invalidTheme = {} } = baseTheme;
+
+  const theme = { ...baseTheme };
+  if (invalid) Object.assign(theme, invalidTheme);
 
   return [
     {
-      color: checkbox.bg,
-      backgroundColor: checkbox.bg,
-      border: invalid ? `1px solid ${checkbox.invalidFg}` : checkbox.border ? `1px solid ${checkbox.border}` : 'none',
+      color: theme.bg,
+      backgroundColor: theme.bg,
+      border: theme.border ? `1px solid ${theme.border}` : 'none',
 
       height: '14px',
       width: '14px',
@@ -68,8 +73,8 @@ export const checkboxStyles = ({ isChecked, isDisabled, invalid }: ICheckboxStyl
       transition: 'background-color .15s ease-in-out',
     },
     isChecked && {
-      color: checkbox.fg,
-      backgroundColor: checkbox.checked,
+      color: theme.fg,
+      backgroundColor: theme.checked,
     },
     isDisabled && {
       opacity: 0.6,

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -7,10 +7,11 @@ import { Box, Flex, IBox, useTheme } from './';
 export interface ICheckbox extends Omit<IBox<HTMLLabelElement>, 'as|onChange'> {
   checked?: boolean;
   onChange?: (checked: boolean) => void;
+  invalid?: boolean;
 }
 
 export const Checkbox: FunctionComponent<ICheckbox> = props => {
-  const { disabled: isDisabled, onChange, ...rest } = props;
+  const { disabled: isDisabled, onChange, invalid, ...rest } = props;
 
   const [checked, setValue] = useState<boolean>(!!props.checked);
   const isChecked = props.hasOwnProperty('checked') ? !!props.checked : checked;
@@ -22,7 +23,7 @@ export const Checkbox: FunctionComponent<ICheckbox> = props => {
 
   return (
     // @ts-ignore FIXME issue with border-box in styling
-    <Flex {...rest} as="label" css={checkboxStyles({ isDisabled, isChecked })}>
+    <Flex {...rest} as="label" css={checkboxStyles({ isDisabled, isChecked, invalid })}>
       <Box
         as="input"
         type="checkbox"
@@ -41,14 +42,14 @@ export const Checkbox: FunctionComponent<ICheckbox> = props => {
   );
 };
 
-export const checkboxStyles = ({ isChecked, isDisabled }: ICheckboxStyles) => {
+export const checkboxStyles = ({ isChecked, isDisabled, invalid }: ICheckboxStyles) => {
   const { checkbox } = useTheme();
 
   return [
     {
       color: checkbox.bg,
       backgroundColor: checkbox.bg,
-      border: checkbox.border ? `1px solid ${checkbox.border}` : 'none',
+      border: invalid ? `1px solid ${checkbox.invalid}` : checkbox.border ? `1px solid ${checkbox.border}` : 'none',
 
       height: '14px',
       width: '14px',
@@ -80,4 +81,5 @@ export const checkboxStyles = ({ isChecked, isDisabled }: ICheckboxStyles) => {
 interface ICheckboxStyles {
   isChecked: boolean;
   isDisabled: boolean;
+  invalid: boolean;
 }

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -43,7 +43,12 @@ export const Input: React.FunctionComponent<IInput> = props => {
 
 const inputStyles = ({ disabled, invalid }: IInput) => {
   const { input: baseTheme } = useTheme();
-  const { invalid: invalidTheme = {} } = baseTheme;
+
+  const invalidTheme = {
+    fg: baseTheme.invalidFg,
+    bg: baseTheme.invalidBg,
+    border: baseTheme.invalidBorder,
+  };
 
   const theme = { ...baseTheme };
   if (invalid) Object.assign(theme, invalidTheme);

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -8,6 +8,7 @@ import { useTheme } from './theme';
 
 export interface IInput extends IBox<HTMLInputElement> {
   autosize?: boolean;
+  invalid?: boolean;
 }
 
 const AutosizeWrapper: React.FunctionComponent<Partial<{ className: string }>> = ({ className, ...props }) => (
@@ -15,7 +16,7 @@ const AutosizeWrapper: React.FunctionComponent<Partial<{ className: string }>> =
 );
 
 export const Input: React.FunctionComponent<IInput> = props => {
-  const { as = 'input', autosize, onChange = noop, type, ...rest } = props;
+  const { as = 'input', autosize, onChange = noop, type, invalid, ...rest } = props;
 
   // TODO: do we want controlled mode here?
   const [value, setValue] = React.useState(props.value);
@@ -40,14 +41,14 @@ export const Input: React.FunctionComponent<IInput> = props => {
   );
 };
 
-const inputStyles = ({ disabled }: IInput) => {
+const inputStyles = ({ disabled, invalid }: IInput) => {
   const { input } = useTheme();
 
   return [
     {
       color: input.fg,
       backgroundColor: input.bg,
-      border: input.border ? `1px solid ${input.border}` : 'none',
+      border: invalid ? `1px solid ${input.invalid}` : input.border ? `1px solid ${input.border}` : 'none',
 
       padding: '0px 10px',
       minHeight: '30px',

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -48,7 +48,7 @@ const inputStyles = ({ disabled, invalid }: IInput) => {
     {
       color: input.fg,
       backgroundColor: input.bg,
-      border: invalid ? `1px solid ${input.invalid}` : input.border ? `1px solid ${input.border}` : 'none',
+      border: invalid ? `1px solid ${input.invalidFg}` : input.border ? `1px solid ${input.border}` : 'none',
 
       padding: '0px 10px',
       minHeight: '30px',

--- a/src/Input.tsx
+++ b/src/Input.tsx
@@ -42,13 +42,17 @@ export const Input: React.FunctionComponent<IInput> = props => {
 };
 
 const inputStyles = ({ disabled, invalid }: IInput) => {
-  const { input } = useTheme();
+  const { input: baseTheme } = useTheme();
+  const { invalid: invalidTheme = {} } = baseTheme;
+
+  const theme = { ...baseTheme };
+  if (invalid) Object.assign(theme, invalidTheme);
 
   return [
     {
-      color: input.fg,
-      backgroundColor: input.bg,
-      border: invalid ? `1px solid ${input.invalidFg}` : input.border ? `1px solid ${input.border}` : 'none',
+      color: theme.fg,
+      backgroundColor: theme.bg,
+      border: theme.border ? `1px solid ${theme.border}` : 'none',
 
       padding: '0px 10px',
       minHeight: '30px',

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -133,22 +133,23 @@ export const Select: React.FunctionComponent<ISelect> = props => {
  */
 
 const customStyles = (invalid: boolean) => {
-  const { select: selectTheme } = useTheme();
-
-  if (!selectTheme) {
+  const { select: baseTheme } = useTheme();
+  if (!baseTheme) {
     return {};
   }
+  const { chip: chipTheme, menu: menuTheme, invalid: invalidTheme = {} } = baseTheme;
 
-  const { chip: chipTheme, menu: menuTheme } = selectTheme;
+  const theme = { ...baseTheme };
+  if (invalid) Object.assign(theme, invalidTheme);
 
   return {
     clearIndicator: (provided: any, { isDisabled }: { isDisabled: boolean }) => ({
       ...provided,
-      color: selectTheme.border || selectTheme.fg,
+      color: theme.border || theme.fg,
       padding: '0px',
 
       ':hover': {
-        color: selectTheme.border || selectTheme.fg,
+        color: theme.border || theme.fg,
         opacity: !isDisabled && 0.6,
       },
     }),
@@ -158,13 +159,9 @@ const customStyles = (invalid: boolean) => {
     }),
     control: (provided: any, { isDisabled }: { isDisabled: boolean }) => ({
       ...provided,
-      color: selectTheme.fg,
-      backgroundColor: selectTheme.bg,
-      border: invalid
-        ? `1px solid ${selectTheme.invalidFg}`
-        : selectTheme.border
-          ? `1px solid ${selectTheme.border}`
-          : 'none',
+      color: theme.fg,
+      backgroundColor: theme.bg,
+      border: theme.border ? `1px solid ${theme.border}` : 'none',
 
       minWidth: '147px',
       minHeight: '30px',
@@ -180,29 +177,29 @@ const customStyles = (invalid: boolean) => {
       opacity: isDisabled && 0.6,
 
       ':hover': {
-        borderColor: invalid ? selectTheme.invalidFg : selectTheme.border,
+        borderColor: theme.border,
       },
     }),
     dropdownIndicator: (provided: any, { isDisabled }: { isDisabled: boolean }) => ({
       ...provided,
-      color: selectTheme.border || selectTheme.fg,
+      color: theme.border || theme.fg,
 
       padding: '0px',
 
       ':hover': {
-        color: selectTheme.border || selectTheme.fg,
+        color: theme.border || theme.fg,
         opacity: !isDisabled && 0.6,
       },
     }),
     indicatorSeparator: (provided: any) => ({
       ...provided,
-      backgroundColor: selectTheme.border || selectTheme.fg,
+      backgroundColor: theme.border || theme.fg,
       marginLeft: '5px',
       marginRight: '5px',
     }),
     input: (provided: any, { isDisabled }: { isDisabled: false }) => ({
       ...provided,
-      color: selectTheme.fg,
+      color: theme.fg,
 
       padding: '0px',
       cursor: isDisabled ? 'not-allowed' : 'pointer',
@@ -210,7 +207,7 @@ const customStyles = (invalid: boolean) => {
     }),
     loadingIndicator: (provided: any) => ({
       ...provided,
-      color: selectTheme.border || selectTheme.fg,
+      color: theme.border || theme.fg,
       padding: '0px',
     }),
     loadingMessage: (provided: any) => ({
@@ -291,13 +288,13 @@ const customStyles = (invalid: boolean) => {
     }),
     placeholder: (provided: any) => ({
       ...provided,
-      color: selectTheme.fg,
+      color: theme.fg,
 
       opacity: 0.6,
     }),
     singleValue: (provided: any) => ({
       ...provided,
-      color: selectTheme.fg,
+      color: theme.fg,
       padding: '0px',
     }),
 

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -35,6 +35,7 @@ export interface ISelectBaseProps {
   closeOnScroll?: boolean;
 
   allowCreate?: boolean;
+  invalid?: boolean;
 }
 
 export interface ISelectProps
@@ -82,6 +83,7 @@ export const Select: React.FunctionComponent<ISelect> = props => {
     noOptionsMessage = 'No Options',
 
     allowCreate = false,
+    invalid = false,
 
     ...selectProps
   } = props;
@@ -106,7 +108,7 @@ export const Select: React.FunctionComponent<ISelect> = props => {
     onMenuScrollToBottom: onScrollToBottom,
     ...selectProps,
     // CUSTOM STYLES
-    styles: customStyles(),
+    styles: customStyles(invalid),
   };
 
   if ('loadOptions' in props && ('onCreateOption' in props || allowCreate)) {
@@ -130,7 +132,7 @@ export const Select: React.FunctionComponent<ISelect> = props => {
  * override color related
  */
 
-const customStyles = () => {
+const customStyles = (invalid: boolean) => {
   const { select: selectTheme } = useTheme();
 
   if (!selectTheme) {
@@ -158,7 +160,11 @@ const customStyles = () => {
       ...provided,
       color: selectTheme.fg,
       backgroundColor: selectTheme.bg,
-      border: selectTheme.border ? `1px solid ${selectTheme.border}` : 'none',
+      border: invalid
+        ? `1px solid ${selectTheme.invalidFg}`
+        : selectTheme.border
+          ? `1px solid ${selectTheme.border}`
+          : 'none',
 
       minWidth: '147px',
       minHeight: '30px',
@@ -174,7 +180,7 @@ const customStyles = () => {
       opacity: isDisabled && 0.6,
 
       ':hover': {
-        borderColor: selectTheme.border,
+        borderColor: invalid ? selectTheme.invalidFg : selectTheme.border,
       },
     }),
     dropdownIndicator: (provided: any, { isDisabled }: { isDisabled: boolean }) => ({

--- a/src/Select.tsx
+++ b/src/Select.tsx
@@ -137,7 +137,14 @@ const customStyles = (invalid: boolean) => {
   if (!baseTheme) {
     return {};
   }
-  const { chip: chipTheme, menu: menuTheme, invalid: invalidTheme = {} } = baseTheme;
+
+  const invalidTheme = {
+    fg: baseTheme.invalidFg,
+    bg: baseTheme.invalidBg,
+    border: baseTheme.invalidBorder,
+  };
+
+  const { chip: chipTheme, menu: menuTheme } = baseTheme;
 
   const theme = { ...baseTheme };
   if (invalid) Object.assign(theme, invalidTheme);

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -7,10 +7,11 @@ import { useTheme } from './theme';
 
 export interface ITextarea extends IBox<HTMLTextAreaElement> {
   autosize?: boolean;
+  invalid?: boolean;
 }
 
 export const Textarea: React.FunctionComponent<ITextarea> = props => {
-  const { autosize, as = 'textarea', onChange = noop, ...rest } = props;
+  const { autosize, as = 'textarea', onChange = noop, invalid, ...rest } = props;
 
   // TODO: do we want controlled mode here?
   const [value, setValue] = React.useState<string>(props.value || '');
@@ -32,14 +33,14 @@ export const Textarea: React.FunctionComponent<ITextarea> = props => {
   );
 };
 
-export const textareaStyles = ({ autosize, disabled }: ITextarea): IBoxCSS => {
+export const textareaStyles = ({ autosize, disabled, invalid }: ITextarea): IBoxCSS => {
   const { textarea } = useTheme();
 
   return [
     {
       color: textarea.fg,
       backgroundColor: textarea.bg,
-      border: textarea.border ? `1px solid ${textarea.border}` : 'none',
+      border: invalid ? `1px solid ${textarea.invalidFg}` : textarea.border ? `1px solid ${textarea.border}` : 'none',
 
       // TODO the top/bottom padding is a rough estimation find a better solution
       padding: '7px 10px',

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -34,13 +34,17 @@ export const Textarea: React.FunctionComponent<ITextarea> = props => {
 };
 
 export const textareaStyles = ({ autosize, disabled, invalid }: ITextarea): IBoxCSS => {
-  const { textarea } = useTheme();
+  const { textarea: baseTheme } = useTheme();
+  const { invalid: invalidTheme = {} } = baseTheme;
+
+  const theme = { ...baseTheme };
+  if (invalid) Object.assign(theme, invalidTheme);
 
   return [
     {
-      color: textarea.fg,
-      backgroundColor: textarea.bg,
-      border: invalid ? `1px solid ${textarea.invalidFg}` : textarea.border ? `1px solid ${textarea.border}` : 'none',
+      color: theme.fg,
+      backgroundColor: theme.bg,
+      border: theme.border ? `1px solid ${theme.border}` : 'none',
 
       // TODO the top/bottom padding is a rough estimation find a better solution
       padding: '7px 10px',

--- a/src/Textarea.tsx
+++ b/src/Textarea.tsx
@@ -35,7 +35,12 @@ export const Textarea: React.FunctionComponent<ITextarea> = props => {
 
 export const textareaStyles = ({ autosize, disabled, invalid }: ITextarea): IBoxCSS => {
   const { textarea: baseTheme } = useTheme();
-  const { invalid: invalidTheme = {} } = baseTheme;
+
+  const invalidTheme = {
+    fg: baseTheme.invalidFg,
+    bg: baseTheme.invalidBg,
+    border: baseTheme.invalidBorder,
+  };
 
   const theme = { ...baseTheme };
   if (invalid) Object.assign(theme, invalidTheme);

--- a/src/__stories__/Forms/Checkbox.tsx
+++ b/src/__stories__/Forms/Checkbox.tsx
@@ -14,6 +14,7 @@ const store = new Store<Partial<ICheckbox>>({
 export const checkboxKnobs = (tabName = 'Checkbox'): Partial<ICheckbox> => ({
   disabled: boolean('disabled', false, tabName),
   checked: boolean('checked', false, tabName),
+  invalid: boolean('invalid', false, tabName),
 });
 
 storiesOf('Forms:Checkbox', module)

--- a/src/__stories__/Forms/Input.tsx
+++ b/src/__stories__/Forms/Input.tsx
@@ -20,6 +20,7 @@ export const inputKnobs = (tabName = 'Input'): IInput => ({
   disabled: boolean('disabled', false, tabName),
   type: select('type', InlineInputType, 'text', tabName),
   placeholder: text('placeholder', 'placeholder', tabName),
+  invalid: boolean('invalid', false, tabName),
 });
 
 export const autosizeInputKnobs = (tabName = 'Input'): IInput => ({

--- a/src/__stories__/Forms/Select.tsx
+++ b/src/__stories__/Forms/Select.tsx
@@ -27,6 +27,7 @@ export const selectKnobs = (tabName = 'Select'): ISelect => ({
   hideSelectedOptions: boolean('hideSelectedOptions', false),
   backspaceRemovesValue: boolean('backspaceRemovesValue', true),
   onChange: action('onChange'),
+  invalid: boolean('invalid', false),
 });
 
 storiesOf('Forms:Select', module)

--- a/src/__stories__/Forms/Textarea.tsx
+++ b/src/__stories__/Forms/Textarea.tsx
@@ -17,6 +17,7 @@ export const textareaKnobs = (tabName = 'Textarea'): ITextarea => ({
   ...omit(boxKnobs<HTMLTextAreaElement>(), 'opacity'),
   autosize: boolean('autosize', false, tabName),
   disabled: boolean('disabled', false, tabName),
+  invalid: boolean('invalid', false, tabName),
 });
 
 export const textareaAutosizeKnobs = (tabName = 'Textarea'): ITextarea => ({

--- a/src/__stories__/Views/Components.tsx
+++ b/src/__stories__/Views/Components.tsx
@@ -2,12 +2,18 @@ import * as React from 'react';
 
 import { faPlus } from '@fortawesome/free-solid-svg-icons';
 import { withKnobs } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs/react';
 import { storiesOf } from '@storybook/react';
 
 import { Box, Button, Checkbox, Flex, Icon, IconLibrary, Input, Textarea, Toggle } from '../../';
 import { Select } from '../../Select';
 
 IconLibrary.add(faPlus);
+
+const knobs = () => ({
+  invalid: boolean('invalid', false),
+  disabled: boolean('disabled', false),
+});
 
 storiesOf('Views:Components', module)
   .addDecorator(withKnobs)
@@ -17,38 +23,39 @@ const App = () => {
   return (
     <Flex alignItems="center">
       <Box mr="3">
-        <Button>Button</Button>
+        <Button {...knobs()}>Button</Button>
       </Box>
 
       <Box mr="3">
-        <Button>
+        <Button {...knobs()}>
           <Icon icon="plus" />
         </Button>
       </Box>
 
       <Box mr="3">
-        <Checkbox />
+        <Checkbox {...knobs()} />
       </Box>
 
       <Box mr="3">
-        <Toggle />
+        <Toggle {...knobs()} />
       </Box>
 
       <Box mr="3">
-        <Input placeholder="placeholder" />
+        <Input placeholder="placeholder" {...knobs()} />
       </Box>
 
       <Box mr="3">
-        <Textarea placeholder="placeholder" />
+        <Textarea placeholder="placeholder" {...knobs()} />
       </Box>
 
       <Box mr="3">
-        <Select placeholder="select" options={['1', '2', '3', '4'].map(x => ({ value: x, label: x }))} />
+        <Select placeholder="select" {...knobs()} options={['1', '2', '3', '4'].map(x => ({ value: x, label: x }))} />
       </Box>
 
       <Box mr="3">
         <Select
           placeholder="select-multi"
+          {...knobs()}
           isMulti={true}
           options={['1', '2', '3', '4'].map(x => ({ value: x, label: x }))}
         />

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -10,11 +10,9 @@ const inputTheme: ITheme['input'] = {
   fg: '#f5f8fa',
   bg: 'rgb(65, 65, 65)',
   border: opacityBorder,
-  invalid: {
-    fg: 'red',
-    bg: 'rgba(200,0,0,0.15)',
-    border: 'darkred',
-  },
+  invalidFg: 'red',
+  invalidBg: 'rgba(200,0,0,0.15)',
+  invalidBorder: 'darkred',
 };
 
 const buttonTheme: ITheme['button'] = {
@@ -28,12 +26,10 @@ const checkboxTheme: ITheme['checkbox'] = {
   ...buttonTheme,
   fg: 'rgb(65, 65, 65)',
   checked: 'steelblue',
-  invalid: {
-    fg: 'red',
-    bg: 'rgb(45, 18, 17)',
-    checked: 'rgb(45, 18, 17)',
-    border: 'darkred',
-  },
+  invalidFg: 'red',
+  invalidBg: 'rgb(45, 18, 17)',
+  invalidChecked: 'rgb(45, 18, 17)',
+  invalidBorder: 'darkred',
 };
 
 const menuTheme: ITheme['menu'] = {

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -108,6 +108,7 @@ export const darkTheme: ITheme = {
     fg: '#f5f8fa',
     bg: 'rgba(92, 92, 92, 0.5)',
     border: 'rgba(16,22,26,.2)',
+    invalidFg: 'darkred',
   },
 
   tabs: {

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -82,6 +82,7 @@ export const darkTheme: ITheme = {
     fg: '#BFCCD6',
     bg: '#202D36',
     border: '#1B262E',
+    invalidFg: 'darkred',
 
     chip: {
       fg: '#BFCCD6',

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -8,9 +8,13 @@ const opacityBorder = 'rgba(16,22,26,.15)';
 
 const inputTheme: ITheme['input'] = {
   fg: '#f5f8fa',
-  bg: 'rgba(92, 92, 92, 0.5)',
+  bg: 'rgb(65, 65, 65)',
   border: opacityBorder,
-  invalidFg: 'darkred',
+  invalid: {
+    fg: 'red',
+    bg: 'rgba(200,0,0,0.15)',
+    border: 'darkred',
+  },
 };
 
 const buttonTheme: ITheme['button'] = {
@@ -22,9 +26,14 @@ const buttonTheme: ITheme['button'] = {
 
 const checkboxTheme: ITheme['checkbox'] = {
   ...buttonTheme,
-  fg: 'white',
+  fg: 'rgb(65, 65, 65)',
   checked: 'steelblue',
-  invalidFg: 'darkred',
+  invalid: {
+    fg: 'red',
+    bg: 'rgb(45, 18, 17)',
+    checked: 'rgb(45, 18, 17)',
+    border: 'darkred',
+  },
 };
 
 const menuTheme: ITheme['menu'] = {

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -19,6 +19,7 @@ export const darkTheme: ITheme = {
     fg: 'white',
     bg: 'white',
     checked: 'mediumseagreen',
+    invalid: 'darkred',
   },
 
   codeEditor: {
@@ -55,6 +56,7 @@ export const darkTheme: ITheme = {
     fg: '#f5f8fa',
     bg: 'rgba(92, 92, 92, 0.5)',
     border: 'rgba(16,22,26,.2)',
+    invalid: 'darkred',
   },
 
   link: {

--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -19,7 +19,7 @@ export const darkTheme: ITheme = {
     fg: 'white',
     bg: 'white',
     checked: 'mediumseagreen',
-    invalid: 'darkred',
+    invalidFg: 'darkred',
   },
 
   codeEditor: {
@@ -56,7 +56,7 @@ export const darkTheme: ITheme = {
     fg: '#f5f8fa',
     bg: 'rgba(92, 92, 92, 0.5)',
     border: 'rgba(16,22,26,.2)',
-    invalid: 'darkred',
+    invalidFg: 'darkred',
   },
 
   link: {

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -10,6 +10,7 @@ const inputTheme: ITheme['input'] = {
   fg: '#222',
   bg: '#fff',
   border: opacityBorder,
+  invalid: 'red',
 };
 
 const checkboxTheme: ITheme['checkbox'] = {
@@ -17,6 +18,7 @@ const checkboxTheme: ITheme['checkbox'] = {
   bg: 'rgb(245, 248, 250)',
   border: opacityBorder,
   checked: 'steelblue',
+  invalid: 'red',
 };
 
 const menuTheme: ITheme['menu'] = {

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -10,7 +10,7 @@ const inputTheme: ITheme['input'] = {
   fg: '#222',
   bg: '#fff',
   border: opacityBorder,
-  invalid: 'red',
+  invalidFg: 'red',
 };
 
 const checkboxTheme: ITheme['checkbox'] = {
@@ -18,7 +18,7 @@ const checkboxTheme: ITheme['checkbox'] = {
   bg: 'rgb(245, 248, 250)',
   border: opacityBorder,
   checked: 'steelblue',
-  invalid: 'red',
+  invalidFg: 'red',
 };
 
 const menuTheme: ITheme['menu'] = {

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -10,11 +10,9 @@ const inputTheme: ITheme['input'] = {
   fg: '#222',
   bg: '#fff',
   border: opacityBorder,
-  invalid: {
-    fg: 'red',
-    bg: 'rgba(200,0,0,0.15)',
-    border: 'red',
-  },
+  invalidFg: 'red',
+  invalidBg: 'rgb(248, 222, 220)',
+  invalidBorder: 'red',
 };
 
 const buttonTheme: ITheme['button'] = {
@@ -28,12 +26,10 @@ const checkboxTheme: ITheme['checkbox'] = {
   ...buttonTheme,
   fg: 'white',
   checked: 'steelblue',
-  invalid: {
-    fg: 'red',
-    bg: 'rgba(200,0,0,0.15)',
-    checked: 'rgba(200,0,0,0.15)',
-    border: 'red',
-  },
+  invalidFg: 'red',
+  invalidBg: 'rgb(248, 222, 220)',
+  invalidChecked: 'rgb(248, 222, 220)',
+  invalidBorder: 'red',
 };
 
 const menuTheme: ITheme['menu'] = {

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -10,7 +10,11 @@ const inputTheme: ITheme['input'] = {
   fg: '#222',
   bg: '#fff',
   border: opacityBorder,
-  invalidFg: 'red',
+  invalid: {
+    fg: 'red',
+    bg: 'rgba(200,0,0,0.15)',
+    border: 'red',
+  },
 };
 
 const buttonTheme: ITheme['button'] = {
@@ -24,7 +28,12 @@ const checkboxTheme: ITheme['checkbox'] = {
   ...buttonTheme,
   fg: 'white',
   checked: 'steelblue',
-  invalidFg: 'red',
+  invalid: {
+    fg: 'red',
+    bg: 'rgba(200,0,0,0.15)',
+    checked: 'rgba(200,0,0,0.15)',
+    border: 'red',
+  },
 };
 
 const menuTheme: ITheme['menu'] = {

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -21,7 +21,7 @@ export interface ITheme {
     bg: string;
     border?: string;
     checked: string;
-    invalid?: string;
+    invalidFg?: string;
   };
 
   contextMenu: {
@@ -48,7 +48,7 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
-    invalid?: string;
+    invalidFg?: string;
   };
 
   codeEditor: {
@@ -93,7 +93,7 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
-    invalid?: string;
+    invalidFg?: string;
 
     chip: {
       fg: string;
@@ -121,7 +121,7 @@ export interface ITheme {
     fg: string;
     bg?: string;
     border?: string;
-    invalid?: string;
+    invalidFg?: string;
   };
 
   tabs: {

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -21,12 +21,10 @@ export interface ITheme {
     bg: string;
     border?: string;
     checked: string;
-    invalid?: {
-      fg?: string;
-      bg?: string;
-      border?: string;
-      checked?: string;
-    };
+    invalidFg?: string;
+    invalidBg?: string;
+    invalidBorder?: string;
+    invalidChecked?: string;
   };
 
   contextMenu: {
@@ -53,11 +51,9 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
-    invalid?: {
-      fg?: string;
-      bg?: string;
-      border?: string;
-    };
+    invalidFg?: string;
+    invalidBg?: string;
+    invalidBorder?: string;
   };
 
   codeEditor: {
@@ -102,11 +98,9 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
-    invalid?: {
-      fg?: string;
-      bg?: string;
-      border?: string;
-    };
+    invalidFg?: string;
+    invalidBg?: string;
+    invalidBorder?: string;
 
     chip: {
       fg: string;
@@ -135,11 +129,9 @@ export interface ITheme {
     fg: string;
     bg?: string;
     border?: string;
-    invalid?: {
-      fg?: string;
-      bg?: string;
-      border?: string;
-    };
+    invalidFg?: string;
+    invalidBg?: string;
+    invalidBorder?: string;
   };
 
   tabs: {

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -21,6 +21,7 @@ export interface ITheme {
     bg: string;
     border?: string;
     checked: string;
+    invalid?: string;
   };
 
   contextMenu: {
@@ -47,6 +48,7 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
+    invalid?: string;
   };
 
   codeEditor: {
@@ -91,6 +93,7 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
+    invalid?: string;
 
     chip: {
       fg: string;
@@ -118,6 +121,7 @@ export interface ITheme {
     fg: string;
     bg?: string;
     border?: string;
+    invalid?: string;
   };
 
   tabs: {

--- a/src/theme/types.ts
+++ b/src/theme/types.ts
@@ -21,7 +21,12 @@ export interface ITheme {
     bg: string;
     border?: string;
     checked: string;
-    invalidFg?: string;
+    invalid?: {
+      fg?: string;
+      bg?: string;
+      border?: string;
+      checked?: string;
+    };
   };
 
   contextMenu: {
@@ -48,7 +53,11 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
-    invalidFg?: string;
+    invalid?: {
+      fg?: string;
+      bg?: string;
+      border?: string;
+    };
   };
 
   codeEditor: {
@@ -93,7 +102,11 @@ export interface ITheme {
     fg: string;
     bg: string;
     border?: string;
-    invalidFg?: string;
+    invalid?: {
+      fg?: string;
+      bg?: string;
+      border?: string;
+    };
 
     chip: {
       fg: string;
@@ -122,7 +135,11 @@ export interface ITheme {
     fg: string;
     bg?: string;
     border?: string;
-    invalidFg?: string;
+    invalid?: {
+      fg?: string;
+      bg?: string;
+      border?: string;
+    };
   };
 
   tabs: {


### PR DESCRIPTION
Add an optional `invalid` prop to `Checkbox`, `Input`, `Select`, and `Textarea` that activates the invalid style variant.

Normal, Light:
![image](https://user-images.githubusercontent.com/587740/52888522-f38d2d00-3149-11e9-8f63-cd500a7bdf54.png)

Invalid, Light:
![image](https://user-images.githubusercontent.com/587740/52888531-fd169500-3149-11e9-960a-ca6329ec33b7.png)

Normal, Dark:
![image](https://user-images.githubusercontent.com/587740/52888537-09025700-314a-11e9-95d1-cdb932ba5481.png)

Invalid, Dark:
![image](https://user-images.githubusercontent.com/587740/52888549-13bcec00-314a-11e9-8767-63f747a6e2d7.png)
