### PR TITLE
fix: remove unnecessary transparency

### DIFF
--- a/src/theme/dark.ts
+++ b/src/theme/dark.ts
@@ -11,15 +11,15 @@ const inputTheme: ITheme['input'] = {
   bg: 'rgb(65, 65, 65)',
   border: opacityBorder,
   invalidFg: 'red',
-  invalidBg: 'rgba(200,0,0,0.15)',
+  invalidBg: 'rgb(45, 18, 17)',
   invalidBorder: 'darkred',
 };
 
 const buttonTheme: ITheme['button'] = {
   fg: 'white',
-  bg: 'rgba(255, 255, 255, 0.2)',
+  bg: 'rgb(65, 65, 65)',
   border: opacityBorder,
-  hoverBg: 'rgba(255, 255, 255, 0.3)',
+  hoverBg: 'rgb(89, 89, 89)',
 };
 
 const checkboxTheme: ITheme['checkbox'] = {
@@ -72,10 +72,10 @@ export const darkTheme: ITheme = {
 
   code: {
     bg: '#28303a',
-    border: 'rgba(255, 255, 255, 0.2)',
+    border: 'rgb(83, 89, 97)',
 
     inlineFg: 'inherit',
-    inlineBg: 'rgba(255, 255, 255, 0.25)',
+    inlineBg: 'rgb(77, 77, 77)',
 
     syntax: {
       primary: '#e91e63',
@@ -131,17 +131,17 @@ export const darkTheme: ITheme = {
 
   table: {
     fg: 'inherit',
-    border: 'rgba(255, 255, 255, 0.25)',
+    border: 'rgb(77, 77, 77)',
     shadow: '0 0 10px 1px rgba(255,255,255,0.6) inset',
-    evenBg: 'rgba(255, 255, 255, 0.05)',
+    evenBg: 'rgb(29, 29, 29)',
   },
 
   textarea: inputTheme,
 
   tabs: {
     bg: '#28303a',
-    fg: 'rgba(255, 255, 255, 0.6)',
-    border: 'rgba(255, 255, 255, 0.2)',
+    fg: 'rgb(168, 172, 175)',
+    border: 'rgb(65, 65, 65)',
     selectedFg: '#fff',
     selectedBg: '#1b2129',
   },

--- a/src/theme/light.ts
+++ b/src/theme/light.ts
@@ -74,7 +74,7 @@ export const lightTheme: ITheme = {
     bg: '#F5F7F9',
     border: '#E6ECF1',
     inlineFg: '#1a1a1a',
-    inlineBg: 'rgba(255, 229, 100, 0.3)',
+    inlineBg: 'rgb(255, 247, 211)',
 
     syntax: {
       primary: '#e91e63',


### PR DESCRIPTION
I left transparency in where it made sense: shadows, overlay, scrollbars.

# Before
![image](https://user-images.githubusercontent.com/587740/53435835-c05b6100-39c7-11e9-887b-da2ba2bc1975.png)

# After
![image](https://user-images.githubusercontent.com/587740/53435792-9e61de80-39c7-11e9-9fcf-462adbce98b0.png)
