### PR TITLE
fix: context menu needs to render a placeholder

### DIFF
--- a/src/ContextMenu.tsx
+++ b/src/ContextMenu.tsx
@@ -73,7 +73,8 @@ export const ContextMenuView: React.FunctionComponent<IContextMenuView> = props 
 
   // Only show context menu if we have items to show
   if (!menuItems.length) {
-    return null;
+    // We still need to render a placeholder so the context menu can reference the menu to show/hide
+    return <Box {...viewProps} as={ReactContextMenu} css={{ display: 'none' }} />;
   }
 
   return (

--- a/src/ContextMenu.tsx
+++ b/src/ContextMenu.tsx
@@ -71,14 +71,8 @@ export const ContextMenuView: React.FunctionComponent<IContextMenuView> = props 
 
   const { contextMenu: theme } = useTheme();
 
-  // Only show context menu if we have items to show
-  if (!menuItems.length) {
-    // We still need to render a placeholder so the context menu can reference the menu to show/hide
-    return <Box {...viewProps} as={ReactContextMenu} css={{ display: 'none' }} />;
-  }
-
   return (
-    <Box {...viewProps} as={ReactContextMenu} css={menuStyles(theme)}>
+    <Box {...viewProps} as={ReactContextMenu} css={menuStyles(theme, menuItems.length > 0)}>
       {menuItems.map((item, index) => {
         return <ContextMenuItem key={index} {...item} />;
       })}
@@ -86,7 +80,12 @@ export const ContextMenuView: React.FunctionComponent<IContextMenuView> = props 
   );
 };
 
-const menuStyles = (theme: ITheme['contextMenu']) => {
+const menuStyles = (theme: ITheme['contextMenu'], hasMenuItems: boolean) => {
+  // Only show context menu if we have items to show
+  if (!hasMenuItems) {
+    return [{ display: 'none' }];
+  }
+
   return [
     {
       color: theme.fg,
@@ -167,7 +166,7 @@ export const ContextMenuItem: React.FunctionComponent<IContextMenuItem> = props 
     return (
       <Box
         {...rest}
-        css={menuStyles(theme)}
+        css={menuStyles(theme, true)}
         as={({ className }: { className: string }) => {
           return (
             <ReactSubMenu

--- a/src/__tests__/ContextMenu.spec.tsx
+++ b/src/__tests__/ContextMenu.spec.tsx
@@ -95,10 +95,11 @@ describe('ContextMenuView component', () => {
     jest.unmock('../theme');
   });
 
-  it('should render null when no menuItems are passed in', () => {
+  it('should render an empty placeholder element', () => {
     const wrapper = shallow(<ContextMenuView id="t" menuItems={[]} />);
 
-    expect(wrapper.type()).toBeNull();
+    expect(wrapper).toHaveProp('as', ReactContextMenu);
+    expect(wrapper.find(ContextMenuItem)).toHaveLength(0);
   });
 
   it('should iterate over menuItems and render ContextMenuItem', () => {


### PR DESCRIPTION
We can't return null from `ContextMenuView` because it has internal state that is used to render when triggered by `ContextMenuTrigger`. Instead of returning null when we don't have any menu items, we instead return a placeholder.