### PR TITLE
docs: revisit and clarify some parts SL-1879

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ IconLibrary.add(faCaretDown);
 
 ## Helpful Links
 
-- Guideline for "good" Storybook stories: https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07
+- [Guideline for "good" Storybook stories](https://blog.hichroma.com/the-delightful-storybook-workflow-b322b76fd07)
 
 - Emotion
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/f0df5b38120a6471be33/maintainability)](https://codeclimate.com/repos/5bdb489c9a98842d0a00d211/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/f0df5b38120a6471be33/test_coverage)](https://codeclimate.com/repos/5bdb489c9a98842d0a00d211/test_coverage)
 
-Stoplight UI-Kit is a shared component library that contains basic components built using [Emotion](https://emotion.sh)
-and [Styled System](https://styled-system.com) All components should support overridable theming from a theme object, and also come with default styling from our prepackaged theme.
+Stoplight UI-Kit is a shared component library that contains basic components built using [Emotion](https://emotion.sh) and [Styled System](https://styled-system.com) All components should support overridable theming from a theme object, and also come with default styling from our prepackaged theme.
 
 - Explore the components: [Storybook](https://stoplightio.github.io/ui-kit/)
 - View the changelog: [Releases](https://github.com/stoplightio/ui-kit/releases)
@@ -68,7 +67,14 @@ IconLibrary.add(faCaretDown);
 
 ### Migration guide
 
-- [See the relative document](./docs/migration.md)
+In case you're porting a component from another Stoplight's Library [see the this document for some guidance](./docs/migration.md)
+
+### Anti panic Faq
+
+1. What are all these `m, mt, mb, pt` properties on all the components I've got?
+
+    These are properties injected by [styled system](https://jxnblk.com/styled-system/). To get a complete reference of these, please
+    have a look the [reference table](https://styled-system.com/table)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -55,32 +55,6 @@ IconLibrary.add(faCaretDown);
 - [Components](./docs/components.md)
   - [Creating a component](./docs/components.md#creating-a-component)
   - [Extending a styled component](./docs/components.md#extending-a-component)
-  - Component List
-    - Badge
-    - BlockQuote
-    - Box
-    - Break
-    - Button
-    - Code Editor
-    - Context Menu
-    - Flex
-    - Heading
-    - Icon
-    - Image
-    - Input
-    - Link
-    - List
-    - Menu
-    - Popup
-    - Portal
-    - ScrollBox
-    - ScrollList
-    - Select
-    - Table
-    - Text
-    - Tabs
-    - Textarea
-    - Toggle
 
 ## Helpful Links
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/f0df5b38120a6471be33/maintainability)](https://codeclimate.com/repos/5bdb489c9a98842d0a00d211/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/f0df5b38120a6471be33/test_coverage)](https://codeclimate.com/repos/5bdb489c9a98842d0a00d211/test_coverage)
 
-Stoplight ui-kit is a shared component library that contains basic components built using styled-components. All components should support overridable theming from a theme object, and also come with default styling from our prepackaged theme.
+Stoplight UI-Kit is a shared component library that contains basic components built using [Emotion](https://emotion.sh)
+and [Styled System](https://styled-system.com) All components should support overridable theming from a theme object, and also come with default styling from our prepackaged theme.
 
 - Explore the components: [Storybook](https://stoplightio.github.io/ui-kit/)
 - View the changelog: [Releases](https://github.com/stoplightio/ui-kit/releases)
@@ -41,11 +42,6 @@ import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 IconLibrary.add(faCaretDown);
 ```
 
-
-### Migration guide
-
-- [guide](./docs/migration.md)
-
 ## API Reference
 
 - [Theme](./docs/theme.md)
@@ -69,6 +65,10 @@ IconLibrary.add(faCaretDown);
 
   - [Git Repo](https://github.com/jxnblk/styled-system)
   - [Site](https://jxnblk.com/styled-system/)
+
+### Migration guide
+
+- [See the relative document](./docs/migration.md)
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 IconLibrary.add(faCaretDown);
 ```
 
-## API Reference
+## Docs
 
 - [Theme](./docs/theme.md)
   - [base](./docs/theme-base.md)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ IconLibrary.add(faCaretDown);
 
 In case you're porting a component from another Stoplight's Library [see the this document for some guidance](./docs/migration.md)
 
-### Anti panic Faq
+### FAQ
 
 1. What are all these `m, mt, mb, pt` properties on all the components I've got?
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -3,27 +3,12 @@
 All components in this library use Emotion to implement styling, and a subset of style functions from styled-system.
 Theming is accomplished via ThemeZones that rely on React's context.
 
-## Creating a component
-
-In most cases you should refer to [Extending a component](#extending-a-component) section.
-A vast amount of components are based on Box, so you won't really need to reinvent the wheel every time.
-If you build a more complex component, such as Toggle, wrap some other React component specific (i.e. Code Editor or Select) or just have a very specific use case, you may prefer not to base the new component on Box.
-There is no general rule how to implement such a component - it's strictly related to a use case.
-It's all about having a common sense here.
-
-Just think what's actually needed, how much customizable it's supposed be etc.
-
-You can refer to:
-
-- [Context Menu](https://github.com/stoplightio/ui-kit/blob/master/src/ContextMenu.tsx)
-- [Code Editor](https://github.com/stoplightio/ui-kit/blob/master/src/CodeEditor.tsx)
-- [Menu](https://github.com/stoplightio/ui-kit/blob/master/src/Menu.tsx)
-- [Select](https://github.com/stoplightio/ui-kit/blob/master/src/Select.tsx)
-- [Toggle](https://github.com/stoplightio/ui-kit/blob/master/src/Toggle.tsx)
 
 ## Extending a component
 
-It's advisable to base off your new component on Box/Flex/Text, which are foundational components for almost all styled components in UI-Kit.
+It's advisable (let's say compulsory) to base off your new component on `Box/Flex/Text`, which are foundational components
+for almost all styled components in UI-Kit.
+
 This will guarantee your props will be properly passed and a ref will be forwarded.
 
 ```typescript jsx
@@ -118,3 +103,23 @@ BlockQuote.displayName = 'BlockQuote';
 
 export { BlockQuote };
 ```
+
+## Creating a component
+
+In most cases you should refer to [Extending a component](#extending-a-component) section.
+A vast amount of components are based on Box, so you won't really need to reinvent the wheel every time.
+If you build a more complex component, such as Toggle, wrap some other React component specific (i.e. Code Editor or Select) or just have a very specific use case, you may prefer not to base the new component on Box.
+
+There is no general rule how to implement such a component - it's strictly related to a use case.
+
+It's all about having a common sense here.
+
+Just think what's actually needed, how much customizable it's supposed be etc.
+
+You can refer to:
+
+- [Context Menu](https://github.com/stoplightio/ui-kit/blob/master/src/ContextMenu.tsx)
+- [Code Editor](https://github.com/stoplightio/ui-kit/blob/master/src/CodeEditor.tsx)
+- [Menu](https://github.com/stoplightio/ui-kit/blob/master/src/Menu.tsx)
+- [Select](https://github.com/stoplightio/ui-kit/blob/master/src/Select.tsx)
+- [Toggle](https://github.com/stoplightio/ui-kit/blob/master/src/Toggle.tsx)

--- a/docs/theme-base.md
+++ b/docs/theme-base.md
@@ -1,7 +1,7 @@
 # Theme Base
 
-UI-Kit does not contain any base theme on its own, but there are least 2 ways to exchange the common values for spacing, colors etc.
-They can be used at the same time.
+UI-Kit does not contain any base theme on its own, but there are least 2 ways to exchange the common values for spacing,
+colors etc, which can be used at the same time.
 
 ### Custom theme
 

--- a/docs/theme-base.md
+++ b/docs/theme-base.md
@@ -1,7 +1,6 @@
 # Theme Base
 
-UI-Kit does not contain any base theme on its own, but there are least 2 ways to exchange the common values for spacing,
-colors etc, which can be used at the same time.
+UI-Kit does not contain any base theme on its own, but there are least 2 ways to exchange the common values for spacing, colors etc, which can be used at the same time.
 
 ### Custom theme
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -152,4 +152,3 @@ export interface ICustomTheme extends DeepPartial<ITheme> {
   base: BaseTheme;
 }
 ```
-


### PR DESCRIPTION
* Fix some imprecise parts (we're not using styled-components, for example)
* Remove the component list (it was outdated and not providing any useful help)
* Use embedded markdown links where possible
* Add a FAQ about what are the "strange" properties (this is what would have helped me)
* Put the migration guide on bottom
* Put the Creating a Component section on the bottom since it's not the default use case

