### PR TITLE
fix(icon): drop icon size prop

### DIFF
--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -7,21 +7,12 @@ import {
   library,
   PullProp,
   RotateProp,
-  SizeProp,
   Transform,
 } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Box, IBox } from './Box';
 
-export {
-  IconProp,
-  FlipProp,
-  SizeProp,
-  PullProp,
-  RotateProp,
-  Transform,
-  FaSymbol,
-} from '@fortawesome/fontawesome-svg-core';
+export { IconProp, FlipProp, PullProp, RotateProp, Transform, FaSymbol } from '@fortawesome/fontawesome-svg-core';
 
 export const IconLibrary = library;
 
@@ -34,7 +25,6 @@ export interface IIcon extends IBox<HTMLOrSVGElement> {
   inverse?: boolean;
   listItem?: boolean;
   flip?: FlipProp;
-  size?: SizeProp;
   pull?: PullProp;
   rotation?: RotateProp;
   transform?: string | Transform;

--- a/src/__stories__/Utilities/Icon.tsx
+++ b/src/__stories__/Utilities/Icon.tsx
@@ -43,12 +43,6 @@ export const iconKnobs = (tabName = 'Icon'): any => {
     flip,
     rotation,
     spin: boolean('spin', false, tabName),
-    size: select(
-      'size',
-      ['xs', 'lg', 'sm', '1x', '2x', '3x', '4x', '5x', '6x', '7x', '8x', '9x', '10x'],
-      'sm',
-      tabName
-    ),
     pulse: boolean('pulse', false, tabName),
   };
 


### PR DESCRIPTION
Repos checked that use ui-kit

- studio https://github.com/stoplightio/studio/pull/162
- json-schema-viewer https://github.com/stoplightio/json-schema-viewer/pull/8
- json-schema-editor https://github.com/stoplightio/json-schema-editor/pull/11
- tree-list https://github.com/stoplightio/tree-list/pull/51
- formtron (icon size not used)
- monaco (icon size not used)
- markdown-viewer (icon size not used)
- platform (icon size not used)
