### PR TITLE
Sl 1904/spacing values

### DIFF
--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -8,6 +8,7 @@ import * as ss from 'styled-system';
 import flattenDeep = require('lodash/flattenDeep');
 
 import * as sl from './styles';
+import { useTheme } from './theme';
 import { validPropsPicker } from './utils/validPropsPicker';
 
 const Box: React.FunctionComponent<IBox<HTMLOrSVGElement>> = forwardRef<HTMLOrSVGElement, IBox<HTMLOrSVGElement>>(
@@ -80,6 +81,8 @@ const Box: React.FunctionComponent<IBox<HTMLOrSVGElement>> = forwardRef<HTMLOrSV
       ...rest
     } = props;
 
+    const theme = useTheme();
+
     /** Add all the supported styles, passing in the relevant props. */
     const styles: IBoxCSS = [
       sl.color({ color, backgroundColor }),
@@ -88,7 +91,8 @@ const Box: React.FunctionComponent<IBox<HTMLOrSVGElement>> = forwardRef<HTMLOrSV
       ss.borderColor({ borderColor }),
       ss.boxShadow({ boxShadow }),
       sl.boxSizing({ boxSizing }),
-      sl.space({ m, mt, mb, ml, mr, mx, my, p, pt, pb, pl, pr, px, py }),
+      // requires theme
+      sl.space({ theme, m, mt, mb, ml, mr, mx, my, p, pt, pb, pl, pr, px, py }),
       ss.flex({ flex }),
       ss.alignSelf({ alignSelf }),
 

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -88,7 +88,7 @@ const Box: React.FunctionComponent<IBox<HTMLOrSVGElement>> = forwardRef<HTMLOrSV
       ss.borderColor({ borderColor }),
       ss.boxShadow({ boxShadow }),
       sl.boxSizing({ boxSizing }),
-      ss.space({ m, mt, mb, ml, mr, mx, my, p, pt, pb, pl, pr, px, py }),
+      sl.space({ m, mt, mb, ml, mr, mx, my, p, pt, pb, pl, pr, px, py }),
       ss.flex({ flex }),
       ss.alignSelf({ alignSelf }),
 

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -20,8 +20,8 @@ const Button: React.FunctionComponent<IButton> = React.forwardRef<HTMLButtonElem
 
   return (
     <Flex
-      px={3}
-      py={2}
+      px={11}
+      py={7}
       borderRadius={2}
       {...rest}
       as={as}

--- a/src/__stories__/Misc/Dialog.tsx
+++ b/src/__stories__/Misc/Dialog.tsx
@@ -22,7 +22,7 @@ storiesOf('Miscellaneous:Dialog', module)
   .addDecorator(withKnobs)
   .add('with defaults', () => (
     <Dialog {...dialogKnobs()} onClickOutside={action('onClickOutside')}>
-      <Heading py={4} px={5} textAlign="center">
+      <Heading py={15} px={20} textAlign="center">
         Remove file?
       </Heading>
       <Button width="50%">yes</Button>

--- a/src/__stories__/Misc/Popup.tsx
+++ b/src/__stories__/Misc/Popup.tsx
@@ -90,7 +90,7 @@ storiesOf('Miscellaneous:Popup', module)
       {...popupKnobs()}
       padding={3}
       renderContent={() => (
-        <Box border={`1px solid red`} borderRadius="10px" p={2}>
+        <Box border={`1px solid red`} borderRadius="10px" p={7}>
           This is a tooltip message.
         </Box>
       )}

--- a/src/__stories__/Views/Layout.tsx
+++ b/src/__stories__/Views/Layout.tsx
@@ -25,25 +25,25 @@ const App = () => {
   const theme = useTheme();
 
   return (
-    <Flex flexDirection="column" textAlign="center" p={2} pt={4} position="relative" border="1px solid">
+    <Flex flexDirection="column" textAlign="center" p={7} pt={15} position="relative" border="1px solid">
       <BoxBadge color={theme.link.fg}>Flex Column</BoxBadge>
 
-      <CustomStoryBox p={4}>[zone: none] the default root theme values, with some extra padding</CustomStoryBox>
+      <CustomStoryBox p={15}>[zone: none] the default root theme values, with some extra padding</CustomStoryBox>
 
-      <Flex p={2} pt={4} mt={2} position="relative" backgroundColor="red">
+      <Flex p={7} pt={15} mt={7} position="relative" backgroundColor="red">
         <BoxBadge>Flex Row</BoxBadge>
 
         <ThemeZone name="inner">
-          <CustomStoryBox flex="1" p={3} pt={4} mr={2}>
+          <CustomStoryBox flex="1" p={11} pt={15} mr={7}>
             <Box>[zone: 'inner'] defaults canvas.bg to purple and canvas.fg to white</Box>
-            <Button mt={3}>Go</Button>
+            <Button mt={11}>Go</Button>
           </CustomStoryBox>
         </ThemeZone>
 
         <ThemeZone name="inverted">
-          <CustomStoryBox flex="1" p={3} pt={4}>
+          <CustomStoryBox flex="1" p={11} pt={15}>
             <Box>[zone: 'inverted'] inverts canvas bg and fg</Box>
-            <Button mt={3}>Go</Button>
+            <Button mt={11}>Go</Button>
           </CustomStoryBox>
         </ThemeZone>
       </Flex>
@@ -57,7 +57,7 @@ const BoxBadge: React.FunctionComponent<IBox> = props => (
     position="absolute"
     top={0}
     right={0}
-    px={1}
+    px={4}
     py="1px"
     fontStyle="italic"
     {...props}

--- a/src/__tests__/Dialog.spec.tsx
+++ b/src/__tests__/Dialog.spec.tsx
@@ -7,7 +7,7 @@ import { IDialog } from '../Dialog';
 import { IOverlay } from '../Overlay';
 import { ITheme } from '../theme';
 
-let useContextSpy: jest.Mock<{}, any>;
+let useContextSpy: jest.SpyInstance;
 describe('Dialog component', () => {
   let Overlay: React.FunctionComponent<IOverlay>;
   let Dialog: React.FunctionComponent<IDialog>;

--- a/src/__tests__/Dialog.spec.tsx
+++ b/src/__tests__/Dialog.spec.tsx
@@ -32,6 +32,8 @@ describe('Dialog component', () => {
       return { Portal: fn };
     });
 
+    jest.spyOn(React, 'useContext').mockReturnValue({});
+
     ({ Overlay, Dialog } = await import('../'));
   });
 

--- a/src/__tests__/Dialog.spec.tsx
+++ b/src/__tests__/Dialog.spec.tsx
@@ -7,6 +7,7 @@ import { IDialog } from '../Dialog';
 import { IOverlay } from '../Overlay';
 import { ITheme } from '../theme';
 
+let useContextSpy: jest.Mock<{}, any>;
 describe('Dialog component', () => {
   let Overlay: React.FunctionComponent<IOverlay>;
   let Dialog: React.FunctionComponent<IDialog>;
@@ -32,7 +33,7 @@ describe('Dialog component', () => {
       return { Portal: fn };
     });
 
-    jest.spyOn(React, 'useContext').mockReturnValue({});
+    useContextSpy = jest.spyOn(React, 'useContext').mockReturnValue({});
 
     ({ Overlay, Dialog } = await import('../'));
   });
@@ -40,6 +41,8 @@ describe('Dialog component', () => {
   afterAll(() => {
     jest.unmock('../theme');
     jest.unmock('../Portal');
+
+    useContextSpy.mockRestore();
   });
 
   it('should render nothing is show is falsy', () => {

--- a/src/__tests__/Flex.spec.tsx
+++ b/src/__tests__/Flex.spec.tsx
@@ -5,9 +5,14 @@ import * as React from 'react';
 import { Box } from '../Box';
 import { Flex, IFlex } from '../Flex';
 
+let useContextSpy: jest.Mock<{}, any>;
 describe('Flex component', () => {
   beforeAll(async () => {
-    jest.spyOn(React, 'useContext').mockReturnValue({});
+    useContextSpy = jest.spyOn(React, 'useContext').mockReturnValue({});
+  });
+
+  afterAll(() => {
+    useContextSpy.mockRestore();
   });
 
   it('renders Box component', () => {

--- a/src/__tests__/Flex.spec.tsx
+++ b/src/__tests__/Flex.spec.tsx
@@ -6,6 +6,10 @@ import { Box } from '../Box';
 import { Flex, IFlex } from '../Flex';
 
 describe('Flex component', () => {
+  beforeAll(async () => {
+    jest.spyOn(React, 'useContext').mockReturnValue({});
+  });
+
   it('renders Box component', () => {
     const wrapper = shallow(<Flex />).shallow();
     expect(wrapper).toMatchElement(<Box />);

--- a/src/__tests__/Flex.spec.tsx
+++ b/src/__tests__/Flex.spec.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Box } from '../Box';
 import { Flex, IFlex } from '../Flex';
 
-let useContextSpy: jest.Mock<{}, any>;
+let useContextSpy: jest.SpyInstance;
 describe('Flex component', () => {
   beforeAll(async () => {
     useContextSpy = jest.spyOn(React, 'useContext').mockReturnValue({});

--- a/src/__tests__/Image.spec.tsx
+++ b/src/__tests__/Image.spec.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { Box } from '../Box';
 import { Image } from '../Image';
 
-let useContextSpy: jest.Mock<{}, any>;
+let useContextSpy: jest.SpyInstance;
 describe('Image component', () => {
   beforeAll(async () => {
     useContextSpy = jest.spyOn(React, 'useContext').mockReturnValue({});

--- a/src/__tests__/Image.spec.tsx
+++ b/src/__tests__/Image.spec.tsx
@@ -5,9 +5,14 @@ import * as React from 'react';
 import { Box } from '../Box';
 import { Image } from '../Image';
 
+let useContextSpy: jest.Mock<{}, any>;
 describe('Image component', () => {
   beforeAll(async () => {
-    jest.spyOn(React, 'useContext').mockReturnValue({});
+    useContextSpy = jest.spyOn(React, 'useContext').mockReturnValue({});
+  });
+
+  afterAll(() => {
+    useContextSpy.mockRestore();
   });
 
   it('renders Box as img', () => {

--- a/src/__tests__/Image.spec.tsx
+++ b/src/__tests__/Image.spec.tsx
@@ -6,6 +6,10 @@ import { Box } from '../Box';
 import { Image } from '../Image';
 
 describe('Image component', () => {
+  beforeAll(async () => {
+    jest.spyOn(React, 'useContext').mockReturnValue({});
+  });
+
   it('renders Box as img', () => {
     const wrapper = shallow(<Image />).shallow();
     expect(wrapper).toMatchElement(<Box as="img" />);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -21,7 +21,6 @@ import {
 } from 'csstype';
 
 import * as ss from 'styled-system';
-import { useTheme } from './theme';
 
 /**
  * BOX SIZE
@@ -180,13 +179,12 @@ export const whiteSpace = (props: IWhiteSpaceProps) => ({
 /**
  * SPACE
  * we overwrite styled-system space function to have better space prop priority p > px > pr
+ * NEED TO PASS THEME FOR THIS RULE TO USE OUR PREDEFINED VALUES
  */
 
 // @ts-ignore missing type
 export const space = ss.mapProps((props: ss.SpaceProps) => ({
   ...props,
-  // need to pass theme to rule
-  theme: useTheme(),
   mt: !isNil(props.mt) ? props.mt : props.my,
   mb: !isNil(props.mb) ? props.mb : props.my,
   ml: !isNil(props.ml) ? props.ml : props.mx,

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,3 +1,5 @@
+import isNil = require('lodash/isNil');
+
 import {
   BackgroundColorProperty,
   BoxSizingProperty,
@@ -17,6 +19,9 @@ import {
   VisibilityProperty,
   WhiteSpaceProperty,
 } from 'csstype';
+
+import * as ss from 'styled-system';
+import { useTheme } from './theme';
 
 /**
  * BOX SIZE
@@ -171,3 +176,46 @@ export interface IWhiteSpaceProps {
 export const whiteSpace = (props: IWhiteSpaceProps) => ({
   whiteSpace: props.whiteSpace,
 });
+
+/**
+ * SPACE
+ * we overwrite styled-system space function to have better space prop priority p > px > pr
+ */
+
+// @ts-ignore missing type
+export const space = ss.mapProps((props: ss.SpaceProps) => ({
+  ...props,
+  // need to pass theme to rule
+  theme: useTheme(),
+  mt: !isNil(props.mt) ? props.mt : props.my,
+  mb: !isNil(props.mb) ? props.mb : props.my,
+  ml: !isNil(props.ml) ? props.ml : props.mx,
+  mr: !isNil(props.mr) ? props.mr : props.mx,
+  pt: !isNil(props.pt) ? props.pt : props.py,
+  pb: !isNil(props.pb) ? props.pb : props.py,
+  pl: !isNil(props.pl) ? props.pl : props.px,
+  pr: !isNil(props.pr) ? props.pr : props.px,
+}))(
+  ss.compose(
+    // @ts-ignore missing type
+    ss.margin,
+    // @ts-ignore missing type
+    ss.marginTop,
+    // @ts-ignore missing type
+    ss.marginBottom,
+    // @ts-ignore missing type
+    ss.marginLeft,
+    // @ts-ignore missing type
+    ss.marginRight,
+    // @ts-ignore missing type
+    ss.padding,
+    // @ts-ignore missing type
+    ss.paddingTop,
+    // @ts-ignore missing type
+    ss.paddingBottom,
+    // @ts-ignore missing type
+    ss.paddingLeft,
+    // @ts-ignore missing type
+    ss.paddingRight
+  )
+);

--- a/src/theme/configuration.ts
+++ b/src/theme/configuration.ts
@@ -1,0 +1,40 @@
+// styled-system overrides, these can be overwritten by user themese but this is not advised
+const space = {
+  0: '0px',
+  // increase by 2*0 = 1
+  1: '1px',
+  2: '2px',
+  3: '3px',
+  4: '4px',
+  5: '5px',
+
+  // increase by 2*1 = 2
+  6: '6px',
+  7: '8px',
+  8: '10px',
+  9: '12px',
+  10: '14px',
+
+  // increase by 2*2 = 4
+  11: '18px',
+  12: '22px',
+  13: '26px',
+  14: '30px',
+  15: '34px',
+
+  // increase by 2*3 = 6
+  16: '40px',
+  17: '46px',
+  18: '52px',
+  19: '60px',
+  20: '66px',
+
+  // increase by 2*4 = 8
+  21: '78px',
+  22: '86px',
+  23: '94px',
+  24: '102px',
+  25: '110px',
+};
+
+export const configuration = { space };

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -2,8 +2,10 @@ import { Dictionary, Omit } from '@stoplight/types';
 import merge = require('lodash/merge');
 import * as React from 'react';
 
+import { configuration } from './configuration';
 import { darkTheme } from './dark';
 import { lightTheme } from './light';
+
 import { BaseTheme, ICustomTheme, ITheme } from './types';
 
 export * from './types';
@@ -48,7 +50,7 @@ export const ThemeProvider: React.FunctionComponent<IThemeProvider<any, any>> = 
   const targetTheme = theme || defaultTheme;
 
   return (
-    <Theme.Provider value={merge({}, baseThemes[targetTheme.base], targetTheme)}>
+    <Theme.Provider value={merge({}, configuration, baseThemes[targetTheme.base], targetTheme)}>
       <ThemeZones.Provider value={zones}>{children}</ThemeZones.Provider>
     </Theme.Provider>
   );


### PR DESCRIPTION
With this update we will need to updated the spacing values in all relevant repos

- [x] ui/kit
- [x] studio https://github.com/stoplightio/studio/pull/167
- [x] json-schema-viewer https://github.com/stoplightio/json-schema-viewer/pull/9
- [x] json-schema-editor https://github.com/stoplightio/json-schema-editor/pull/12
- [x] tree-list (no values)
- [x] formtron https://github.com/stoplightio/formtron/pull/47
- [x] monaco (no values)
- [x] markdown-viewer https://github.com/stoplightio/markdown-viewer/pull/7

For reference old scale:
```
const spaceScale = {
  0: 0px,
  1: 4px,
  2: 8px,
  3: 16px,
  4: 32px,
  5: 64px,
  6: 128px,
};
```

new scale 
```
const space = {
  0: '0px',
  // increase by 2*0 = 1
  1: '1px',
  2: '2px',
  3: '3px',
  4: '4px',
  5: '5px',

  // increase by 2*1 = 2
  6: '6px',
  7: '8px',
  8: '10px',
  9: '12px',
  10: '14px',

  // increase by 2*2 = 4
  11: '18px',
  12: '22px',
  13: '26px',
  14: '30px',
  15: '34px',

  // increase by 2*3 = 6
  16: '40px',
  17: '46px',
  18: '52px',
  19: '60px',
  20: '66px',

  // increase by 2*4 = 8
  21: '78px',
  22: '86px',
  23: '94px',
  24: '102px',
  25: '110px',
};
```



pointers
```
old => new
  7 => 25
  6 => 25
  5 => 20
  4 => 15
  3 => 11
  2 => 7
  1 => 4
  0 => 0

```