### PR TITLE
feat: add scrollToItem prop to FixedSizeList

### DIFF
--- a/src/ScrollList/index.tsx
+++ b/src/ScrollList/index.tsx
@@ -35,14 +35,21 @@ export const CustomScrollContainer = React.forwardRef<HTMLDivElement, IFixedSize
 interface IFixedSizeListProps extends Omit<ReactWindow.FixedSizeListProps, 'height' | 'width'> {
   className?: string;
   maxRows?: number;
+  scrollToItem?: number;
 }
 
 const FixedSizeList: React.FunctionComponent<IFixedSizeListProps> = React.forwardRef<
   ReactWindow.FixedSizeList,
   IFixedSizeListProps
 >(function FixedSizeList(props, ref) {
-  const { className, children, itemSize, itemCount, maxRows, style, ...rest } = props;
+  const { className, children, itemSize, itemCount, maxRows, style, scrollToItem, ...rest } = props;
   const listHeight = (min([itemCount, maxRows]) as number) * itemSize;
+
+  const listRef: React.Ref<any> = React.useRef();
+
+  React.useEffect(() => {
+    if (listRef.current && typeof scrollToItem === 'number') listRef.current.scrollToItem(scrollToItem);
+  }, [listRef, scrollToItem]);
 
   return (
     <div style={{ height: maxRows ? listHeight : '100%' }} className="ScrollList-Container">
@@ -59,7 +66,8 @@ const FixedSizeList: React.FunctionComponent<IFixedSizeListProps> = React.forwar
             // style gets passed to SrollList-Scrollbars
             style={style}
             outerRef={ref}
-            outerElementType={CustomScrollContainer}
+            ref={listRef}
+            // outerElementType={CustomScrollContainer}
           >
             {children}
           </ReactWindow.FixedSizeList>

--- a/src/__stories__/ScrollList/index.tsx
+++ b/src/__stories__/ScrollList/index.tsx
@@ -39,12 +39,22 @@ storiesOf('ScrollList-FixedSizeList', module)
       <FixedSizeList {...fixedSizeListKnobs()}>{Row}</FixedSizeList>
     </div>
   ))
-
   .add('maxRows', () => (
     <div style={{ outline: '1px solid currentColor', margin: 50 }}>
       <FixedSizeList
         {...fixedSizeListKnobs()}
         maxRows={number('maxRows', 5, { min: 0, max: Infinity, range: false, step: 1 }, 'FixedSizeList')}
+      >
+        {Row}
+      </FixedSizeList>
+    </div>
+  ))
+  .add('scrollTo', () => (
+    <div style={{ outline: '1px solid currentColor', margin: 50 }}>
+      <FixedSizeList
+        {...fixedSizeListKnobs()}
+        maxRows={number('maxRows', 5, { min: 0, max: Infinity, range: false, step: 1 }, 'FixedSizeList')}
+        scrollToItem={number('scrollToItem', 0, { min: 0, max: Infinity, range: false, step: 1 }, 'FixedSizeList')}
       >
         {Row}
       </FixedSizeList>


### PR DESCRIPTION
# Problem Statement

I'm trying to fix this: selecting search items with the keyboard moves the selection off-screen.

![2019-05-16 15 35 09](https://user-images.githubusercontent.com/587740/57881864-572e0180-77f0-11e9-8eed-2e9ddea7a457.gif)

This is not a problem with Blueprint's native suggest, but is with ours.

![2019-05-16 15 37 17](https://user-images.githubusercontent.com/587740/57881954-8e9cae00-77f0-11e9-8ed4-d44992672cec.gif)


---

# Thoughts on how to fix

I think I can use the `onActiveItemChange` handler of `<Suggest>` so that the selected items stays in view, if we have a way to scroll list items into view. Which we _almost_ do because react-window supports it: https://react-window.now.sh/#/examples/list/scroll-to-item

But.... I'm running into problems with the custom scrollbar container.

Here it is with `outerElementType={CustomScrollContainer}` commented out.

![2019-05-16 15 22 45](https://user-images.githubusercontent.com/587740/57881143-8cd1eb00-77ee-11e9-90c0-4b8d7d5433a6.gif)

I'm using a `scrollToItem` prop and watching it, but am flexible about how the API could be exposed. We just need to demonstrate it can be done first. :/