### PR TITLE
fix: validateOpts causes maximum depth

### DIFF
--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -15,7 +15,7 @@ export const useValidateSchema = (schema?: yup.Schema<any>, value?: any, validat
     } catch (e) {
       setValidationErrors(e.errors || ['Input is invalid']);
     }
-  }, [value, schema, validateOpts]);
+  }, [value, schema]);
 
   return validationErrors;
 };


### PR DESCRIPTION
~Not sure why exactly this was causing the problem but lets just remove it for now~

Since the `validateOpts` object is being created on each render, it invalidates the useEffect on each render which causes it to get into an infinite loop