### PR TITLE
feat(fixed-size-list): visual offset

### DIFF
--- a/src/ScrollList/index.tsx
+++ b/src/ScrollList/index.tsx
@@ -35,14 +35,15 @@ export const CustomScrollContainer = React.forwardRef<HTMLDivElement, IFixedSize
 interface IFixedSizeListProps extends Omit<ReactWindow.FixedSizeListProps, 'height' | 'width'> {
   className?: string;
   maxRows?: number;
+  addOffset?: boolean;
 }
 
 const FixedSizeList: React.FunctionComponent<IFixedSizeListProps> = React.forwardRef<
   ReactWindow.FixedSizeList,
   IFixedSizeListProps
 >(function FixedSizeList(props, ref) {
-  const { className, children, itemSize, itemCount, maxRows, style, ...rest } = props;
-  const listHeight = (min([itemCount, maxRows]) as number) * itemSize;
+  const { className, addOffset, children, itemSize, itemCount, maxRows, style, ...rest } = props;
+  const listHeight = (min([itemCount, maxRows]) as number) * itemSize + (addOffset ? itemSize / 2 : 0);
 
   return (
     <div style={{ height: maxRows ? listHeight : '100%' }} className="ScrollList-Container">

--- a/src/ScrollList/index.tsx
+++ b/src/ScrollList/index.tsx
@@ -35,15 +35,15 @@ export const CustomScrollContainer = React.forwardRef<HTMLDivElement, IFixedSize
 interface IFixedSizeListProps extends Omit<ReactWindow.FixedSizeListProps, 'height' | 'width'> {
   className?: string;
   maxRows?: number;
-  addOffset?: boolean;
+  offset?: number;
 }
 
 const FixedSizeList: React.FunctionComponent<IFixedSizeListProps> = React.forwardRef<
   ReactWindow.FixedSizeList,
   IFixedSizeListProps
 >(function FixedSizeList(props, ref) {
-  const { className, addOffset, children, itemSize, itemCount, maxRows, style, ...rest } = props;
-  const listHeight = (min([itemCount, maxRows]) as number) * itemSize + (addOffset ? itemSize / 2 : 0);
+  const { className, offset = 0, children, itemSize, itemCount, maxRows, style, ...rest } = props;
+  const listHeight = (min([itemCount, maxRows]) as number) * itemSize + offset;
 
   return (
     <div style={{ height: maxRows ? listHeight : '100%' }} className="ScrollList-Container">

--- a/src/__stories__/ScrollList/index.tsx
+++ b/src/__stories__/ScrollList/index.tsx
@@ -14,6 +14,7 @@ import { FixedSizeList, IFixedSizeListProps } from '../../ScrollList';
 export const fixedSizeListKnobs = (tabName = 'FixedSizeList'): Omit<IFixedSizeListProps, 'children'> => ({
   itemCount: number('itemCount', 20, { min: 0, max: Infinity, range: false, step: 1 }, tabName),
   itemSize: number('itemSize', 50, { min: 0, max: Infinity, range: false, step: 1 }, tabName),
+  offset: number('offset', 0, { min: 0, max: Infinity, range: false, step: 1 }, tabName),
 });
 
 /**

--- a/src/__stories__/ScrollList/index.tsx
+++ b/src/__stories__/ScrollList/index.tsx
@@ -14,7 +14,7 @@ import { FixedSizeList, IFixedSizeListProps } from '../../ScrollList';
 export const fixedSizeListKnobs = (tabName = 'FixedSizeList'): Omit<IFixedSizeListProps, 'children'> => ({
   itemCount: number('itemCount', 20, { min: 0, max: Infinity, range: false, step: 1 }, tabName),
   itemSize: number('itemSize', 50, { min: 0, max: Infinity, range: false, step: 1 }, tabName),
-  offset: number('offset', 0, { min: 0, max: Infinity, range: false, step: 1 }, tabName),
+  offset: number('offset', 0, { min: Infinity, max: Infinity, range: false, step: 1 }, tabName),
 });
 
 /**


### PR DESCRIPTION
The property might be useful if you want to add extra padding at the end of the list to highlight the fact you can scroll the list down. Didn't make it a default, as there are cases this might not be the desired behavior.