### PR TITLE
fix(code-viewer): syntax highlighting

### DIFF
--- a/src/__stories__/Code/CodeEditor.tsx
+++ b/src/__stories__/Code/CodeEditor.tsx
@@ -24,6 +24,11 @@ storiesOf('Code:Editor', module)
     <>
       <CodeEditor {...codeEditorKnobs()} onChange={action('onChange')} />
     </>
+  ))
+  .add('dark', () => (
+    <div className="bp3-dark">
+      <CodeEditor {...codeEditorKnobs()} onChange={action('onChange')} />
+    </div>
   ));
 
 storiesOf('Code:Editor', module)

--- a/src/__stories__/Code/CodeViewer.tsx
+++ b/src/__stories__/Code/CodeViewer.tsx
@@ -15,4 +15,9 @@ export const codeViewerKnobs = (tabName = 'Code Viewer'): ICodeViewerProps => ({
 storiesOf('Code:Viewer', module)
   .addDecorator(withKnobs)
   .add('with defaults', () => <CodeViewer {...codeViewerKnobs()} />)
+  .add('dark', () => (
+    <div className="bp3-dark">
+      <CodeViewer {...codeViewerKnobs()} />
+    </div>
+  ))
   .add('inline', () => <CodeViewer {...codeViewerKnobs()} inline />);

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -1,3 +1,6 @@
+@import 'theme-light';
+@import 'theme-dark';
+
 .#{$ns}-code-editor {
   font-family: Inconsolata, Monaco, Consolas, 'Courier New', Courier, monospace;
   background: var(--code-bg);
@@ -6,6 +9,8 @@
   line-height: 1.5;
   hyphens: none;
   direction: ltr;
+
+  @include lightCodeTheme();
 
   ::selection {
     background: var(--code-selection-bg);
@@ -131,5 +136,9 @@
     &.boolean {
       color: var(--code-boolean);
     }
+  }
+
+  .#{$ns}-dark & {
+    @include darkCodeTheme();
   }
 }


### PR DESCRIPTION
Don't add any before/after screenshots, as there is really nothing to compare.
At the moment, everything is displayed as it was a plain text.