### PR TITLE
fix: custom scrollbar container ref forwarding

### DIFF
--- a/src/ScrollContainer/index.tsx
+++ b/src/ScrollContainer/index.tsx
@@ -13,7 +13,7 @@ import { AutoSizer } from '../index';
 export type ScrollbarRefInstance = HTMLDivElement | Scrollbar | null;
 export type ScrollbarRef = (instance: ScrollbarRefInstance) => void;
 
-interface IScrollContainer extends ScrollbarProps {
+interface IScrollContainer extends Omit<ScrollbarProps, 'ref'> {
   shadows?: boolean;
   autosize?: boolean;
 }
@@ -21,12 +21,15 @@ interface IScrollContainer extends ScrollbarProps {
 const ScrollContainer = React.forwardRef<ScrollbarRefInstance, IScrollContainer>(
   ({ id, children, shadows = true, autosize = true, ...props }, scrollbarRef) => {
     const scrollbar = React.useRef<any>(null);
-    const scrollbarCallback: ScrollbarRef = (ref: ScrollbarRefInstance) => {
-      scrollbar.current = ref;
-      if (typeof scrollbarRef === 'function') {
-        (scrollbarRef as ScrollbarRef)(ref);
-      }
-    };
+    const scrollbarCallback = React.useCallback<ScrollbarRef>(
+      ref => {
+        scrollbar.current = ref;
+        if (typeof scrollbarRef === 'function') {
+          scrollbarRef(ref);
+        }
+      },
+      [scrollbarRef],
+    );
 
     const showTracks = React.useCallback(() => {
       if (!scrollbar.current) return;

--- a/src/ScrollContainer/index.tsx
+++ b/src/ScrollContainer/index.tsx
@@ -10,135 +10,140 @@ import { AutoSizer } from '../index';
 /**
  * SCROLL CONTAINER
  */
+export type ScrollbarRefInstance = HTMLDivElement | Scrollbar | null;
+export type ScrollbarRef = (instance: ScrollbarRefInstance) => void;
+
 interface IScrollContainer extends ScrollbarProps {
   shadows?: boolean;
   autosize?: boolean;
 }
 
-const ScrollContainer: React.FunctionComponent<IScrollContainer> = ({
-  id,
-  children,
-  shadows = true,
-  autosize = true,
-  ...props
-}) => {
-  const scrollbar = React.useRef<any>(null);
+const ScrollContainer = React.forwardRef<ScrollbarRefInstance, IScrollContainer>(
+  ({ id, children, shadows = true, autosize = true, ...props }, scrollbarRef) => {
+    const scrollbar = React.useRef<any>(null);
+    const scrollbarCallback: ScrollbarRef = (ref: ScrollbarRefInstance) => {
+      scrollbar.current = ref;
+      if (typeof scrollbarRef === 'function') {
+        (scrollbarRef as ScrollbarRef)(ref);
+      }
+    };
 
-  const showTracks = React.useCallback(() => {
-    if (!scrollbar.current) return;
+    const showTracks = React.useCallback(() => {
+      if (!scrollbar.current) return;
 
-    scrollbar.current.trackXElement.style.opacity = 1;
-    scrollbar.current.trackYElement.style.opacity = 1;
-    scrollbar.current.trackXElement.style.transition = 'opacity 0s';
-    scrollbar.current.trackYElement.style.transition = 'opacity 0s';
-  }, [scrollbar]);
+      scrollbar.current.trackXElement.style.opacity = 1;
+      scrollbar.current.trackYElement.style.opacity = 1;
+      scrollbar.current.trackXElement.style.transition = 'opacity 0s';
+      scrollbar.current.trackYElement.style.transition = 'opacity 0s';
+    }, [scrollbar]);
 
-  const hideTracks = React.useCallback(() => {
-    if (
-      !scrollbar.current ||
-      scrollbar.current.trackXElement.classList.contains('dragging') ||
-      scrollbar.current.trackYElement.classList.contains('dragging')
-    ) {
-      return;
+    const hideTracks = React.useCallback(() => {
+      if (
+        !scrollbar.current ||
+        scrollbar.current.trackXElement.classList.contains('dragging') ||
+        scrollbar.current.trackYElement.classList.contains('dragging')
+      ) {
+        return;
+      }
+
+      scrollbar.current.trackXElement.style.opacity = 0;
+      scrollbar.current.trackYElement.style.opacity = 0;
+      scrollbar.current.trackXElement.style.transition = 'opacity 0.8s';
+      scrollbar.current.trackYElement.style.transition = 'opacity 0.8s';
+    }, [scrollbar]);
+
+    const updateShadows = React.useCallback(
+      (scrollValues: any) => {
+        if (!scrollbar.current || !shadows) return;
+
+        const { scrollTop, scrollHeight, clientHeight } = scrollValues;
+        const shadowTopOpacity = (1 / 20) * scrollTop;
+        const bottomScrollTop = scrollHeight - clientHeight;
+        const shadowBottomOpacity = (1 / 20) * (bottomScrollTop - Math.max(scrollTop, bottomScrollTop));
+        const darkMode = window.document.getElementsByClassName('bp3-dark').length > 0;
+        scrollbar.current.wrapperElement.style.boxShadow = `rgba(${
+          darkMode ? `44, 44, 44` : `221, 221, 221`
+        }, ${shadowTopOpacity}) 0px 7px 8px -7px inset, rgba(${
+          darkMode ? `44, 44, 44` : `221, 221, 221`
+        }, ${shadowBottomOpacity}) 0px -7px 8px -7px inset`;
+      },
+      [scrollbar, shadows],
+    );
+
+    const thumbRenderer = React.useCallback(
+      (props: Pick<ScrollbarThumbProps, Exclude<keyof ScrollbarThumbProps, 'axis'>>) => {
+        const { elementRef, style, className } = props;
+        const styles = omit(style, ['background', 'borderRadius']);
+        return (
+          <div
+            className={cn(
+              className,
+              'bg-darken-4 hover:bg-darken-6 active:bg-darken-7 dark:bg-lighten-4 dark-hover:bg-lighten-5 dark-active:bg-lighten-6',
+            )}
+            style={styles}
+            ref={elementRef}
+          />
+        );
+      },
+      [],
+    );
+
+    const ScrollElem = (
+      <Scrollbar
+        {...props}
+        wrapperProps={{
+          className: Classes.SCROLL_CONTAINER,
+          style: { position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, overflow: 'hidden' },
+        }}
+        trackYProps={{
+          style: {
+            opacity: 0,
+            cursor: 'pointer',
+            background: 'inherit',
+            width: 6,
+            marginRight: 0,
+            borderRadius: 0,
+            top: 0,
+            bottom: 0,
+            height: '100%',
+          },
+        }}
+        trackXProps={{
+          style: {
+            opacity: 0,
+            cursor: 'pointer',
+            background: 'inherit',
+            height: 6,
+            marginBottom: 0,
+            borderRadius: 0,
+            left: 0,
+            right: 0,
+            width: '100%',
+          },
+        }}
+        thumbXProps={{
+          renderer: thumbRenderer,
+        }}
+        thumbYProps={{
+          renderer: thumbRenderer,
+        }}
+        ref={scrollbarCallback}
+        onUpdate={updateShadows}
+        scrollDetectionThreshold={500}
+        onMouseOver={showTracks}
+        onMouseOut={hideTracks}
+      >
+        {children}
+      </Scrollbar>
+    );
+
+    if (autosize) {
+      return <AutoSizer>{({ height, width }) => <div style={{ height, width }}>{ScrollElem}</div>}</AutoSizer>;
     }
 
-    scrollbar.current.trackXElement.style.opacity = 0;
-    scrollbar.current.trackYElement.style.opacity = 0;
-    scrollbar.current.trackXElement.style.transition = 'opacity 0.8s';
-    scrollbar.current.trackYElement.style.transition = 'opacity 0.8s';
-  }, [scrollbar]);
-
-  const updateShadows = React.useCallback(
-    (scrollValues: any) => {
-      if (!scrollbar.current || !shadows) return;
-
-      const { scrollTop, scrollHeight, clientHeight } = scrollValues;
-      const shadowTopOpacity = (1 / 20) * scrollTop;
-      const bottomScrollTop = scrollHeight - clientHeight;
-      const shadowBottomOpacity = (1 / 20) * (bottomScrollTop - Math.max(scrollTop, bottomScrollTop));
-      const darkMode = window.document.getElementsByClassName('bp3-dark').length > 0;
-      scrollbar.current.wrapperElement.style.boxShadow = `rgba(${
-        darkMode ? `44, 44, 44` : `221, 221, 221`
-      }, ${shadowTopOpacity}) 0px 7px 8px -7px inset, rgba(${
-        darkMode ? `44, 44, 44` : `221, 221, 221`
-      }, ${shadowBottomOpacity}) 0px -7px 8px -7px inset`;
-    },
-    [scrollbar, shadows],
-  );
-
-  const thumbRenderer = React.useCallback(
-    (props: Pick<ScrollbarThumbProps, Exclude<keyof ScrollbarThumbProps, 'axis'>>) => {
-      const { elementRef, style, className } = props;
-      const styles = omit(style, ['background', 'borderRadius']);
-      return (
-        <div
-          className={cn(
-            className,
-            'bg-darken-4 hover:bg-darken-6 active:bg-darken-7 dark:bg-lighten-4 dark-hover:bg-lighten-5 dark-active:bg-lighten-6',
-          )}
-          style={styles}
-          ref={elementRef}
-        />
-      );
-    },
-    [],
-  );
-
-  const ScrollElem = (
-    <Scrollbar
-      {...props}
-      wrapperProps={{
-        className: Classes.SCROLL_CONTAINER,
-        style: { position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, overflow: 'hidden' },
-      }}
-      trackYProps={{
-        style: {
-          opacity: 0,
-          cursor: 'pointer',
-          background: 'inherit',
-          width: 6,
-          marginRight: 0,
-          borderRadius: 0,
-          top: 0,
-          bottom: 0,
-          height: '100%',
-        },
-      }}
-      trackXProps={{
-        style: {
-          opacity: 0,
-          cursor: 'pointer',
-          background: 'inherit',
-          height: 6,
-          marginBottom: 0,
-          borderRadius: 0,
-          left: 0,
-          right: 0,
-          width: '100%',
-        },
-      }}
-      thumbXProps={{
-        renderer: thumbRenderer,
-      }}
-      thumbYProps={{
-        renderer: thumbRenderer,
-      }}
-      ref={scrollbar}
-      onUpdate={updateShadows}
-      scrollDetectionThreshold={500}
-      onMouseOver={showTracks}
-      onMouseOut={hideTracks}
-    >
-      {children}
-    </Scrollbar>
-  );
-
-  if (autosize) {
-    return <AutoSizer>{({ height, width }) => <div style={{ height, width }}>{ScrollElem}</div>}</AutoSizer>;
-  }
-
-  return ScrollElem;
-};
+    return ScrollElem;
+  },
+);
 
 ScrollContainer.displayName = 'ScrollContainer';
 

--- a/src/ScrollList/index.tsx
+++ b/src/ScrollList/index.tsx
@@ -6,7 +6,7 @@ import min = require('lodash/min');
 import noop = require('lodash/noop');
 
 import { AutoSizer } from '../AutoSizer';
-import { ScrollContainer } from '../ScrollContainer';
+import { ScrollbarRef, ScrollContainer } from '../ScrollContainer';
 
 /**
  * HELPERS
@@ -15,8 +15,9 @@ import { ScrollContainer } from '../ScrollContainer';
 export const CustomScrollContainer = React.forwardRef<HTMLDivElement, IFixedSizeListProps & { listHeight: number }>(
   ({ onScroll = noop, children, style, className }, ref) => {
     return (
-      <div ref={ref} style={style} className="ScrollList-Scrollbars">
+      <div style={style} className="ScrollList-Scrollbars">
         <ScrollContainer
+          ref={ref as ScrollbarRef}
           // @ts-ignore typings on onScroll are not right?
           onScroll={scrollValues => onScroll({ currentTarget: scrollValues })}
           autosize={false}

--- a/src/ScrollList/index.tsx
+++ b/src/ScrollList/index.tsx
@@ -6,7 +6,7 @@ import min = require('lodash/min');
 import noop = require('lodash/noop');
 
 import { AutoSizer } from '../AutoSizer';
-import { ScrollbarRef, ScrollContainer } from '../ScrollContainer';
+import { ScrollContainer } from '../ScrollContainer';
 
 /**
  * HELPERS
@@ -17,7 +17,7 @@ export const CustomScrollContainer = React.forwardRef<HTMLDivElement, IFixedSize
     return (
       <div style={style} className="ScrollList-Scrollbars">
         <ScrollContainer
-          ref={ref as ScrollbarRef}
+          ref={ref}
           // @ts-ignore typings on onScroll are not right?
           onScroll={scrollValues => onScroll({ currentTarget: scrollValues })}
           autosize={false}


### PR DESCRIPTION
Fixed sized list is passing reference to custom scrollbar container which needs to be forwarded further to scrollbar component. 
When it was attached to div container manipulating list with `instanceRef` was buggy.