### PR TITLE
fix: add negative px margin

### DIFF
--- a/src/styles/tailwind/tailwind.config.js
+++ b/src/styles/tailwind/tailwind.config.js
@@ -228,6 +228,7 @@ module.exports = {
     margin: theme => ({
       auto: 'auto',
       ...theme('spacing'),
+      '-px': '-1px',
       '-1': '-0.25rem',
       '-2': '-0.5rem',
       '-3': '-0.75rem',


### PR DESCRIPTION
- we have positive pixel margin so it make sense to have a negative one.
- useful for overriding a border.

https://github.com/stoplightio/ui-kit/blob/986d1eff587afedc8220f08843e32c7f37bd6bce/src/styles/tailwind/tailwind.config.js#L50