### PR TITLE
fix: code editor and viewer line numbers

### DIFF
--- a/src/CodeEditor/index.tsx
+++ b/src/CodeEditor/index.tsx
@@ -31,17 +31,19 @@ const CodeEditor = React.forwardRef<ReactSimpleCodeEditor, ICodeEditorProps>((pr
   } = props;
 
   // Highlight code on change
-  const highlight = React.useCallback(
-    (code: string) => (language ? highlightCode(code, language, showLineNumbers) : code),
-    [language, showLineNumbers],
-  );
+  const highlight = React.useCallback((code: string) => highlightCode(code, language || '', showLineNumbers), [
+    language,
+    showLineNumbers,
+  ]);
 
   return (
     <ReactSimpleCodeEditor
       {...rest}
       // @ts-ignore FIXME type error
       ref={ref}
-      className={cn(className, 'bp3-code-editor')}
+      className={cn(className, 'bp3-code-editor', {
+        showLineNumbers,
+      })}
       style={style}
       placeholder={placeholder}
       autoFocus={autoFocus}

--- a/src/CodeEditor/index.tsx
+++ b/src/CodeEditor/index.tsx
@@ -42,7 +42,7 @@ const CodeEditor = React.forwardRef<ReactSimpleCodeEditor, ICodeEditorProps>((pr
       // @ts-ignore FIXME type error
       ref={ref}
       className={cn(className, 'bp3-code-editor', {
-        showLineNumbers,
+        'line-numbers': showLineNumbers,
       })}
       style={style}
       placeholder={placeholder}

--- a/src/CodeEditor/utils/highlightCode.ts
+++ b/src/CodeEditor/utils/highlightCode.ts
@@ -8,18 +8,26 @@ import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-yaml';
 
-export const highlightCode = (code: string, language: string, showLineNumbers?: boolean) => {
+export const highlightCode = (code: string = '', language: string, showLineNumbers?: boolean) => {
   const langDef = Prism.languages[language];
-  if (!code || !langDef) return code;
+  if (!code || !langDef) {
+    if (showLineNumbers) {
+      return `<span class="line-number"></span>${code}`;
+    }
+
+    return code;
+  }
 
   try {
     const result = Prism.highlight(code, langDef, language);
 
     if (showLineNumbers) {
-      return result
-        .split('\n')
-        .map(line => `<span class="line-number"></span>${line}`)
-        .join('\n');
+      const splitOnNewLines = result.split('\n');
+      if (splitOnNewLines.length) {
+        return splitOnNewLines.map(line => `<span class="line-number"></span>${line}`).join('\n');
+      }
+
+      return `<span class="line-number"></span>${splitOnNewLines[0]}`;
     }
 
     return result;

--- a/src/CodeViewer/__tests__/Viewer.spec.tsx
+++ b/src/CodeViewer/__tests__/Viewer.spec.tsx
@@ -1,4 +1,4 @@
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import 'jest-enzyme';
 import * as React from 'react';
 import { CodeViewer } from '..';
@@ -8,17 +8,20 @@ describe('Code Viewer component', () => {
     const code = '{}';
     const language = 'json';
 
-    const wrapper = shallow(<CodeViewer language={language} value={code} inline />);
-    expect(wrapper).toHaveText(code);
-    expect(wrapper).toHaveDisplayName('code');
+    const wrapper = mount(<CodeViewer language={language} value={code} inline />);
+    expect(wrapper).toHaveHTML(
+      `<code class="bp3-code-editor isInline"><span class="token punctuation">{</span><span class="token punctuation">}</span></code>`,
+    );
   });
 
   it('renders pre element for block view', () => {
     const code = '{}';
     const language = 'json';
 
-    const wrapper = shallow(<CodeViewer language={language} value={code} />);
-    expect(wrapper).toHaveDisplayName('pre');
+    const wrapper = mount(<CodeViewer language={language} value={code} />);
+    expect(wrapper).toHaveHTML(
+      `<pre class="bp3-code-editor language-json"><span class="token punctuation">{</span><span class="token punctuation">}</span></pre>`,
+    );
   });
 
   it('renders parsed markup if possible', () => {
@@ -26,7 +29,7 @@ describe('Code Viewer component', () => {
     const language = 'javascript';
     const html = `<pre class="bp3-code-editor language-javascript"><span class="token keyword">function</span></pre>`;
 
-    const wrapper = shallow(<CodeViewer language={language} value={code} />);
+    const wrapper = mount(<CodeViewer language={language} value={code} />);
     expect(wrapper).toHaveHTML(html);
   });
 });

--- a/src/CodeViewer/index.tsx
+++ b/src/CodeViewer/index.tsx
@@ -29,6 +29,8 @@ const CodeViewer: React.FunctionComponent<ICodeViewerProps> = ({
 }) => {
   const lang = (language && languageMaps[language]) || language || '';
 
+  const code = React.useMemo(() => highlightCode(value, lang, showLineNumbers), [value, lang, showLineNumbers]);
+
   if (inline) {
     return (
       <code
@@ -37,18 +39,16 @@ const CodeViewer: React.FunctionComponent<ICodeViewerProps> = ({
           showLineNumbers,
         })}
         {...rest}
-      >
-        {value}
-      </code>
+        dangerouslySetInnerHTML={{ __html: code }}
+      />
     );
   }
-
-  const code = highlightCode(value, lang, showLineNumbers);
 
   return (
     <pre
       className={cn(Classes.CODE_EDITOR, className, `language-${lang || 'unknown'}`, {
         isInline: inline,
+        showLineNumbers,
       })}
       {...(rest as React.HTMLAttributes<HTMLPreElement>)}
       dangerouslySetInnerHTML={{ __html: code }}

--- a/src/CodeViewer/index.tsx
+++ b/src/CodeViewer/index.tsx
@@ -36,7 +36,7 @@ const CodeViewer: React.FunctionComponent<ICodeViewerProps> = ({
       <code
         className={cn(Classes.CODE_EDITOR, className, {
           isInline: inline,
-          showLineNumbers,
+          'line-numbers': showLineNumbers,
         })}
         {...rest}
         dangerouslySetInnerHTML={{ __html: code }}
@@ -48,7 +48,7 @@ const CodeViewer: React.FunctionComponent<ICodeViewerProps> = ({
     <pre
       className={cn(Classes.CODE_EDITOR, className, `language-${lang || 'unknown'}`, {
         isInline: inline,
-        showLineNumbers,
+        'line-numbers': showLineNumbers,
       })}
       {...(rest as React.HTMLAttributes<HTMLPreElement>)}
       dangerouslySetInnerHTML={{ __html: code }}

--- a/src/__stories__/Code/CodeEditor.tsx
+++ b/src/__stories__/Code/CodeEditor.tsx
@@ -1,6 +1,6 @@
 import { StateDecorator, Store } from '@sambego/storybook-state';
 import { action } from '@storybook/addon-actions';
-import { boolean, withKnobs } from '@storybook/addon-knobs';
+import { boolean, number, withKnobs } from '@storybook/addon-knobs';
 import { text } from '@storybook/addon-knobs/react';
 import { storiesOf, StoryDecorator } from '@storybook/react';
 import * as React from 'react';
@@ -17,6 +17,7 @@ export const codeEditorKnobs = (tabName = 'Code Editor'): ICodeEditorProps => ({
   onChange: action('onChange'),
   placeholder: text('placeholder', 'placeholder...', tabName),
   showLineNumbers: boolean('showLineNumbers', false, tabName),
+  padding: number('padding', 0, {}, tabName),
 });
 
 storiesOf('Code:Editor', module)

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -25,8 +25,11 @@
     opacity: 0.7;
   }
 
-  textarea {
-    padding-left: 35px !important;
+  &.showLineNumbers {
+    textarea {
+      // Need to use margin here since CodeEditor supports padding: https://github.com/stoplightio/ui-kit/blob/fd1334753a22d527b803b8554bc51761c348d319/src/CodeEditor/index.tsx#L13
+      margin-left: 35px !important;
+    }
   }
 
   .line-number {

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -25,7 +25,7 @@
     opacity: 0.7;
   }
 
-  &.showLineNumbers {
+  &.line-numbers {
     textarea {
       // Need to use margin here since CodeEditor supports padding: https://github.com/stoplightio/ui-kit/blob/fd1334753a22d527b803b8554bc51761c348d319/src/CodeEditor/index.tsx#L13
       margin-left: 35px !important;


### PR DESCRIPTION
- removes left padding when line numbers isn't enabled
- adds line numbers even when the textarea is empty
- adds highlighting to inline code
- adds memoization to prism highlight

![image](https://user-images.githubusercontent.com/7423098/68061328-41df5d80-fcd2-11e9-87be-981429684ba2.png)
