### PR TITLE
fix: add ocaml language support

### DIFF
--- a/src/CodeEditor/utils/highlightCode.ts
+++ b/src/CodeEditor/utils/highlightCode.ts
@@ -16,6 +16,7 @@ import 'prismjs/components/prism-markdown';
 import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-objectivec';
+import 'prismjs/components/prism-ocaml';
 import 'prismjs/components/prism-php';
 import 'prismjs/components/prism-powershell';
 import 'prismjs/components/prism-protobuf';


### PR DESCRIPTION
Add `OCaml` highlighting styles for `CodeEditor` and `CodeViewer`