### PR TITLE
fix(styles): fix dark mode for SimpleTabs

### DIFF
--- a/src/styles/components/SimpleTabs/_base.scss
+++ b/src/styles/components/SimpleTabs/_base.scss
@@ -80,13 +80,13 @@
   &.#{$ns}-dark,
   .#{$ns}-dark & {
     color: get-color(gray, 5);
-    background-color: get-color(gray, 8);
+    background-color: get-color(gray, 7);
     border-color: rgba(16, 22, 26, 0.4);
 
     &.selected-tab {
       color: white;
-      background-color: get-color(gray, 4);
-      border-bottom-color: get-color(gray, 4);
+      background-color: get-color(gray, 8);
+      border-bottom-color: get-color(gray, 8);
 
       &:hover {
         color: white;
@@ -109,7 +109,7 @@
   background-color: white;
 
   .#{$ns}-dark & {
-    background-color: get-color(gray, 4);
+    background-color: get-color(gray, 8);
     border-color: rgba(16, 22, 26, 0.4);
   }
 }


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/587740/77345739-713b4900-6d0b-11ea-956b-5b92024af661.png)

# After
![image](https://user-images.githubusercontent.com/587740/77345831-90d27180-6d0b-11ea-97ce-5f9087eb919b.png)
