### PR TITLE
feat: async validation support for FormInput

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,21 +6,8 @@ jobs:
       - image: circleci/node:11
     steps:
       - checkout
-      - run:
-          name: Download cc-test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
       - run: yarn
-      - run:
-          name: cc-before
-          command: |
-            ./cc-test-reporter before-build
       - run: yarn test.prod
-      - run:
-          name: cc-after
-          command: |
-            ./cc-test-reporter after-build --coverage-input-type lcov --exit-code $?
 
   build:
     docker:

--- a/src/__stories__/FormInput/index.tsx
+++ b/src/__stories__/FormInput/index.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import * as yup from 'yup';
+
+import { withKnobs } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/react';
+
+import { FormInput } from '../../';
+
+storiesOf('FormInput', module)
+  .addDecorator(withKnobs)
+  .add('with synchronous validation', () => (
+    <div className="p-40">
+      <FormInputContainer schema={exampleSyncSchema} />
+    </div>
+  ))
+  .add('with async validation', () => (
+    <div className="p-40">
+      <FormInputContainer schema={exampleAsyncSchema} />
+    </div>
+  ));
+
+const FormInputContainer: React.FC<{ schema: yup.StringSchema }> = ({ schema }) => {
+  const [value, setValue] = React.useState('');
+
+  return (
+    <FormInput
+      value={value}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.value)}
+      schema={schema}
+    />
+  );
+};
+
+const exampleSyncSchema = yup
+  .string()
+  .min(3, 'waaay too short')
+  .max(5, 'waaay too long');
+
+const exampleAsyncSchema = yup.string().test('oddchars', 'The number of characters must be odd', value => {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(value.length % 2 === 1);
+    }, 1000);
+  });
+});

--- a/src/__stories__/index.ts
+++ b/src/__stories__/index.ts
@@ -3,6 +3,7 @@ import './Docs';
 import './Checkbox';
 import './Code';
 import './Dropdown';
+import './FormInput';
 
 import './AutoSizer';
 import './ScrollContainer';

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as yup from 'yup';
 
 const noError: string[] = [];
-const unknownError = ['Input is invalid'];
+const unknownError = ['Unknown error'];
 
 export function useValidateSchema<T>(
   schema?: yup.Schema<T>,

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -1,4 +1,3 @@
-import { isEqual } from 'lodash';
 import * as React from 'react';
 import * as yup from 'yup';
 
@@ -8,36 +7,24 @@ const unknownError = ['Input is invalid'];
 export function useValidateSchema<T>(
   schema?: yup.Schema<T>,
   value?: T,
-  { abortEarly, recursive, context }: yup.ValidateOptions = {},
+  { abortEarly, recursive }: yup.ValidateOptions = {},
 ): string[] {
   const [errors, setErrors] = React.useState<string[]>(noError);
-  const memoizedSchema = useDeepCompareMemoize(schema);
-  const memoizedContext = useDeepCompareMemoize(context);
 
   React.useEffect(() => {
-    if (!memoizedSchema) {
+    if (!schema) {
       setErrors(noError);
       return;
     }
-    memoizedSchema
-      .validate(value, { strict: true, abortEarly, recursive, context: memoizedContext }) // to avoid taking a useEffect dependency on validateOpts that is an object
+    schema
+      .validate(value, { strict: true, abortEarly, recursive }) // to avoid taking a useEffect dependency on validateOpts that is an object
       .then(() => {
         setErrors(noError);
       })
       .catch(e => {
         setErrors(e.errors || unknownError);
       });
-  }, [memoizedSchema, value, abortEarly, recursive, memoizedContext]);
+  }, [schema, value, abortEarly, recursive]);
 
   return errors;
-}
-
-function useDeepCompareMemoize<T>(value: T) {
-  const ref = React.useRef<T>();
-
-  if (!isEqual(value, ref.current)) {
-    ref.current = value;
-  }
-
-  return ref.current;
 }

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -2,27 +2,30 @@ import { isEqual } from 'lodash';
 import * as React from 'react';
 import * as yup from 'yup';
 
+const noError: string[] = [];
+const unknownError = ['Input is invalid'];
+
 export function useValidateSchema(
   schema?: yup.Schema<any>,
   value?: any,
   { abortEarly, recursive, context }: yup.ValidateOptions = {},
 ): string[] {
-  const [errors, setErrors] = React.useState<string[]>([]);
+  const [errors, setErrors] = React.useState<string[]>(noError);
   const memoizedSchema = useDeepCompareMemoize(schema);
   const memoizedContext = useDeepCompareMemoize(context);
 
   React.useEffect(() => {
     if (!memoizedSchema) {
-      setErrors([]);
+      setErrors(noError);
       return;
     }
     memoizedSchema
       .validate(value, { strict: true, abortEarly, recursive, context: memoizedContext }) // to avoid taking a useEffect dependency on validateOpts that is an object
       .then(() => {
-        setErrors([]);
+        setErrors(noError);
       })
       .catch(e => {
-        setErrors(e.errors || ['Input is invalid']);
+        setErrors(e.errors || unknownError);
       });
   }, [memoizedSchema, value, abortEarly, recursive, memoizedContext]);
 

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -1,16 +1,23 @@
 import * as React from 'react';
 import * as yup from 'yup';
 
-export function useValidateSchema(schema?: yup.Schema<any>, value?: any, validateOpts?: yup.ValidateOptions): string[] {
-  return React.useMemo(() => {
-    if (!schema) return [];
+export function useValidateSchema(
+  schema?: yup.Schema<any>,
+  value?: any,
+  { abortEarly, recursive, context }: yup.ValidateOptions = {},
+): string[] {
+  const [errors, setErrors] = React.useState<string[]>([]);
 
-    try {
-      schema.validateSync(value, validateOpts);
-    } catch (e) {
-      return e.errors || ['Input is invalid'];
+  React.useEffect(() => {
+    if (!schema) {
+      setErrors([]);
+      return;
     }
+    schema
+      .validate(value, { strict: true, abortEarly, recursive, context }) // to avoid taking a useEffect dependency on validateOpts that is an object
+      .then(() => setErrors([]))
+      .catch(e => setErrors(e.errors || ['Input is invalid']));
+  }, [schema, value, abortEarly, recursive, context]);
 
-    return [];
-  }, [schema, value, validateOpts]);
+  return errors;
 }

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -5,9 +5,9 @@ import * as yup from 'yup';
 const noError: string[] = [];
 const unknownError = ['Input is invalid'];
 
-export function useValidateSchema(
-  schema?: yup.Schema<any>,
-  value?: any,
+export function useValidateSchema<T>(
+  schema?: yup.Schema<T>,
+  value?: T,
   { abortEarly, recursive, context }: yup.ValidateOptions = {},
 ): string[] {
   const [errors, setErrors] = React.useState<string[]>(noError);


### PR DESCRIPTION
I added async yup schema support for `FormInput`.

This is something that can simplify our lives many times when implementing async validations for hubs.

I additionally added a story to test and demonstrate the behavior, and improved typings a little.