### PR TITLE
feat: debounced validation for `FormInput` / `FormButton`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-tabs": "^3.1.0",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "~1.8.5",
+    "use-debounce": "^3.4.1",
     "yup": "^0.28.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -125,8 +125,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "yarn lint.fix",
-      "git add"
+      "eslint --fix"
     ]
   },
   "husky": {

--- a/src/FormButton/index.tsx
+++ b/src/FormButton/index.tsx
@@ -19,11 +19,11 @@ type OwnProps<T> = {
 type IFormButtonProps<T> = Omit<IButtonProps, 'type' | 'onClick'> & OwnProps<T>;
 
 function FormButton<T>({ schema, data, loading, disabled, onClick, ...buttonProps }: IFormButtonProps<T>) {
-  const { errors, isStale } = useValidateSchema(schema, data);
+  const { errors, isValidating } = useValidateSchema(schema, data);
 
   return (
     <Button
-      disabled={errors.length > 0 || isStale || loading || disabled}
+      disabled={errors.length > 0 || isValidating || loading || disabled}
       loading={loading}
       onClick={onClick}
       {...buttonProps}

--- a/src/FormButton/index.tsx
+++ b/src/FormButton/index.tsx
@@ -25,12 +25,12 @@ const FormButton: React.FunctionComponent<IFormButton> = ({
   onClick = noop,
   ...buttonProps
 }) => {
-  const { errors } = useValidateSchema(schema, data);
+  const { errors, isStale } = useValidateSchema(schema, data);
   const handleClick = React.useCallback(() => onClick(data), [onClick, data]);
 
   return (
     <Button
-      disabled={errors.length > 0 || loading || disabled}
+      disabled={errors.length > 0 || isStale || loading || disabled}
       loading={loading}
       onClick={handleClick}
       {...buttonProps}

--- a/src/FormButton/index.tsx
+++ b/src/FormButton/index.tsx
@@ -25,7 +25,7 @@ const FormButton: React.FunctionComponent<IFormButton> = ({
   onClick = noop,
   ...buttonProps
 }) => {
-  const errors = useValidateSchema(schema, data);
+  const { errors } = useValidateSchema(schema, data);
   const handleClick = React.useCallback(() => onClick(data), [onClick, data]);
 
   return (

--- a/src/FormButton/index.tsx
+++ b/src/FormButton/index.tsx
@@ -19,7 +19,7 @@ type OwnProps<T> = {
 type IFormButtonProps<T> = Omit<IButtonProps, 'type' | 'onClick'> & OwnProps<T>;
 
 function FormButton<T>({ schema, data, loading, disabled, onClick, ...buttonProps }: IFormButtonProps<T>) {
-  const { errors, isValidating } = useValidateSchema(schema, data);
+  const [{ errors, isValidating }] = useValidateSchema(schema, data);
 
   return (
     <Button

--- a/src/FormButton/index.tsx
+++ b/src/FormButton/index.tsx
@@ -1,4 +1,3 @@
-import { noop } from 'lodash';
 import * as React from 'react';
 // TODO: should probably use ajv and json schema
 import * as yup from 'yup';
@@ -11,34 +10,28 @@ import { Button, IButtonProps } from '../index';
  * button that is disabled if the schema doesn't pass validation
  * TODO, add tooltip to explain why its disabled?
  */
-interface IFormButton extends Omit<IButtonProps, 'type' | 'onClick'> {
-  schema?: yup.Schema<any>;
-  data?: any;
-  onClick?: (data: any) => void;
-}
+type OwnProps<T> = {
+  schema?: yup.Schema<T>;
+  data?: T;
+  onClick?: () => void;
+};
 
-const FormButton: React.FunctionComponent<IFormButton> = ({
-  schema,
-  data,
-  loading,
-  disabled,
-  onClick = noop,
-  ...buttonProps
-}) => {
+type IFormButtonProps<T> = Omit<IButtonProps, 'type' | 'onClick'> & OwnProps<T>;
+
+function FormButton<T>({ schema, data, loading, disabled, onClick, ...buttonProps }: IFormButtonProps<T>) {
   const { errors, isStale } = useValidateSchema(schema, data);
-  const handleClick = React.useCallback(() => onClick(data), [onClick, data]);
 
   return (
     <Button
       disabled={errors.length > 0 || isStale || loading || disabled}
       loading={loading}
-      onClick={handleClick}
+      onClick={onClick}
       {...buttonProps}
     />
   );
-};
+}
 
 /**
  * EXPORTS
  */
-export { IFormButton, FormButton };
+export { FormButton };

--- a/src/FormButton/index.tsx
+++ b/src/FormButton/index.tsx
@@ -13,10 +13,9 @@ import { Button, IButtonProps } from '../index';
 type OwnProps<T> = {
   schema?: yup.Schema<T>;
   data?: T;
-  onClick?: () => void;
 };
 
-type IFormButtonProps<T> = Omit<IButtonProps, 'type' | 'onClick'> & OwnProps<T>;
+type IFormButtonProps<T> = Omit<IButtonProps, 'type'> & OwnProps<T>;
 
 function FormButton<T>({ schema, data, loading, disabled, onClick, ...buttonProps }: IFormButtonProps<T>) {
   const [{ errors, isValidating }] = useValidateSchema(schema, data);

--- a/src/FormInput/index.tsx
+++ b/src/FormInput/index.tsx
@@ -90,7 +90,7 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
   errors = [],
   tooltipProps,
 }) => {
-  const { errors: validationErrors, isValidating } = useValidateSchema(schema, value, { abortEarly: false });
+  const [{ errors: validationErrors, isValidating }] = useValidateSchema(schema, value, { abortEarly: false });
   const errs = [...validationErrors, ...errors];
 
   if (isValidating) {

--- a/src/FormInput/index.tsx
+++ b/src/FormInput/index.tsx
@@ -89,8 +89,19 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
   errors = [],
   tooltipProps,
 }) => {
-  const { errors: validationErrors } = useValidateSchema(schema, value, { abortEarly: false });
+  const { errors: validationErrors, isStale } = useValidateSchema(schema, value, { abortEarly: false });
   const errs = [...validationErrors, ...errors];
+
+  if (isStale && errs.length) {
+    return (
+      <Tooltip content="Validating..." position={Position.BOTTOM_RIGHT}>
+        <div tabIndex={-1} style={{ height: iconHeight[size] }} className="mr-2">
+          <Icon icon="outdated" iconSize={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent="danger" />
+        </div>
+      </Tooltip>
+    );
+  }
+
   if (!errs.length) return null;
 
   return (
@@ -111,7 +122,7 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
       {...tooltipProps}
     >
       <div tabIndex={-1} style={{ height: iconHeight[size] }} className="mr-2">
-        <Icon icon="circle" iconSize={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent="danger" />
+        <Icon icon="issue" iconSize={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent="danger" />
       </div>
     </Tooltip>
   );

--- a/src/FormInput/index.tsx
+++ b/src/FormInput/index.tsx
@@ -90,10 +90,10 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
   errors = [],
   tooltipProps,
 }) => {
-  const { errors: validationErrors, isStale } = useValidateSchema(schema, value, { abortEarly: false });
+  const { errors: validationErrors, isValidating } = useValidateSchema(schema, value, { abortEarly: false });
   const errs = [...validationErrors, ...errors];
 
-  if (isStale) {
+  if (isValidating) {
     return (
       <Tooltip content="Validating..." position={Position.BOTTOM_RIGHT}>
         <div tabIndex={-1} style={{ height: iconHeight[size], display: 'flex', alignItems: 'center' }} className="mr-2">

--- a/src/FormInput/index.tsx
+++ b/src/FormInput/index.tsx
@@ -64,10 +64,10 @@ const FormInput: React.FunctionComponent<IInputGroupProps & IFormInputProps & HT
 };
 
 type Size = 'small' | 'default' | 'large';
-const iconPadding: Dictionary<string, Size> = {
-  small: '1px 6px',
-  default: '6px',
-  large: '11px',
+const iconHeight: Dictionary<string, Size> = {
+  small: '24px',
+  default: '30px',
+  large: '40px',
 };
 
 /**
@@ -110,7 +110,7 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
       intent="danger"
       {...tooltipProps}
     >
-      <div tabIndex={-1} style={{ padding: iconPadding[size] }}>
+      <div tabIndex={-1} style={{ height: iconHeight[size] }} className="mr-2">
         <Icon icon="circle" iconSize={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent="danger" />
       </div>
     </Tooltip>

--- a/src/FormInput/index.tsx
+++ b/src/FormInput/index.tsx
@@ -89,7 +89,8 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
   errors = [],
   tooltipProps,
 }) => {
-  const errs = useValidateSchema(schema, value, { abortEarly: false }).concat(errors);
+  const { errors: validationErrors } = useValidateSchema(schema, value, { abortEarly: false });
+  const errs = [...validationErrors, ...errors];
   if (!errs.length) return null;
 
   return (

--- a/src/FormInput/index.tsx
+++ b/src/FormInput/index.tsx
@@ -5,6 +5,7 @@ import {
   InputGroup,
   ITooltipProps,
   Position,
+  Spinner,
   Tooltip,
 } from '@blueprintjs/core';
 import * as React from 'react';
@@ -92,11 +93,11 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
   const { errors: validationErrors, isStale } = useValidateSchema(schema, value, { abortEarly: false });
   const errs = [...validationErrors, ...errors];
 
-  if (isStale && errs.length) {
+  if (isStale) {
     return (
       <Tooltip content="Validating..." position={Position.BOTTOM_RIGHT}>
-        <div tabIndex={-1} style={{ height: iconHeight[size] }} className="mr-2">
-          <Icon icon="outdated" iconSize={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent="danger" />
+        <div tabIndex={-1} style={{ height: iconHeight[size], display: 'flex', alignItems: 'center' }} className="mr-2">
+          <Spinner size={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent={errs.length ? 'danger' : 'primary'} />
         </div>
       </Tooltip>
     );
@@ -121,7 +122,7 @@ const FormInputValidation: React.FunctionComponent<IFormInputValidationProps> = 
       intent="danger"
       {...tooltipProps}
     >
-      <div tabIndex={-1} style={{ height: iconHeight[size] }} className="mr-2">
+      <div tabIndex={-1} style={{ height: iconHeight[size], display: 'flex', alignItems: 'center' }} className="mr-2">
         <Icon icon="issue" iconSize={size === 'small' ? 12 : Icon.SIZE_STANDARD} intent="danger" />
       </div>
     </Tooltip>

--- a/src/__stories__/FormInput/index.tsx
+++ b/src/__stories__/FormInput/index.tsx
@@ -9,11 +9,13 @@ storiesOf('FormInput', module)
   .addDecorator(withKnobs)
   .add('with synchronous validation', () => (
     <div className="p-40">
+      <p>The number of characters must be odd</p>
       <FormInputContainer schema={exampleSyncSchema} />
     </div>
   ))
   .add('with async validation', () => (
     <div className="p-40">
+      <p>The number of characters must be odd</p>
       <FormInputContainer schema={exampleAsyncSchema} />
     </div>
   ));

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -30,5 +30,5 @@ export function useValidateSchema<T>(
       .finally(() => setIsValidating(false));
   }, [schema, debouncedValue, abortEarly, recursive]);
 
-  return { errors, isValidating };
+  return [{ errors, isValidating }];
 }

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -9,8 +9,9 @@ export function useValidateSchema<T>(
   schema?: yup.Schema<T>,
   value?: T,
   { abortEarly, recursive }: yup.ValidateOptions = {},
+  debounceDelay: number = 500,
 ) {
-  const [debouncedValue] = useDebounce(value, 500);
+  const [debouncedValue] = useDebounce(value, debounceDelay);
   const isStale = debouncedValue != value;
 
   const [errors, setErrors] = React.useState<string[]>(noError);

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useDebounce } from 'use-debounce';
 import * as yup from 'yup';
 
 const noError: string[] = [];
@@ -9,6 +10,8 @@ export function useValidateSchema<T>(
   value?: T,
   { abortEarly, recursive }: yup.ValidateOptions = {},
 ) {
+  const [debouncedValue] = useDebounce(value, 500);
+
   const [errors, setErrors] = React.useState<string[]>(noError);
 
   React.useEffect(() => {
@@ -17,14 +20,14 @@ export function useValidateSchema<T>(
       return;
     }
     schema
-      .validate(value, { strict: true, abortEarly, recursive }) // to avoid taking a useEffect dependency on validateOpts that is an object
+      .validate(debouncedValue, { strict: true, abortEarly, recursive }) // to avoid taking a useEffect dependency on validateOpts that is an object
       .then(() => {
         setErrors(noError);
       })
       .catch(e => {
         setErrors(e.errors || unknownError);
       });
-  }, [schema, value, abortEarly, recursive]);
+  }, [schema, debouncedValue, abortEarly, recursive]);
 
   return { errors };
 }

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -8,7 +8,7 @@ export function useValidateSchema<T>(
   schema?: yup.Schema<T>,
   value?: T,
   { abortEarly, recursive }: yup.ValidateOptions = {},
-): string[] {
+) {
   const [errors, setErrors] = React.useState<string[]>(noError);
 
   React.useEffect(() => {
@@ -26,5 +26,5 @@ export function useValidateSchema<T>(
       });
   }, [schema, value, abortEarly, recursive]);
 
-  return errors;
+  return { errors };
 }

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -11,6 +11,7 @@ export function useValidateSchema<T>(
   { abortEarly, recursive }: yup.ValidateOptions = {},
 ) {
   const [debouncedValue] = useDebounce(value, 500);
+  const isStale = debouncedValue != value;
 
   const [errors, setErrors] = React.useState<string[]>(noError);
 
@@ -29,5 +30,5 @@ export function useValidateSchema<T>(
       });
   }, [schema, debouncedValue, abortEarly, recursive]);
 
-  return { errors };
+  return { errors, isStale };
 }

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -12,24 +12,23 @@ export function useValidateSchema<T>(
   debounceDelay: number = 500,
 ) {
   const [debouncedValue] = useDebounce(value, debounceDelay);
-  const isStale = debouncedValue != value;
-
   const [errors, setErrors] = React.useState<string[]>(noError);
+  const [isValidating, setIsValidating] = React.useState(false);
 
   React.useEffect(() => {
     if (!schema) {
       setErrors(noError);
       return;
     }
+
+    setIsValidating(true);
+
     schema
       .validate(debouncedValue, { strict: true, abortEarly, recursive }) // to avoid taking a useEffect dependency on validateOpts that is an object
-      .then(() => {
-        setErrors(noError);
-      })
-      .catch(e => {
-        setErrors(e.errors || unknownError);
-      });
+      .then(() => setErrors(noError))
+      .catch(e => setErrors(e.errors || unknownError))
+      .finally(() => setIsValidating(false));
   }, [schema, debouncedValue, abortEarly, recursive]);
 
-  return { errors, isStale };
+  return { errors, isValidating };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15825,6 +15825,11 @@ use-callback-ref@^1.2.1:
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
   integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
 
+use-debounce@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.1.tgz#361a20e583c1bd4a44f8b29a26793a52a0b84d2c"
+  integrity sha512-KHZPsL+cZvOt/ZAsHTcoAK65ImXU0iG9FDeofuj9uJTdUULF6Gjws8HpK+JlIjZpZ7LTqPHZtEknc+Im4cB3AA==
+
 use-sidecar@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"


### PR DESCRIPTION
This is based on @lottamus's PR feedback for https://github.com/stoplightio/platform-internal/pull/1748

## Summary

Debounces the yup schema validation `FormInput` and `FormButton` have.

## UI changes

These are opinionated, let me know if you want to change anything.

- A valid input still does not show any icon.
- The invalid icon was changed to include an exclamation mark in the middle to be more consistent with the _stale/validating_ icon (see below). 
![image](https://user-images.githubusercontent.com/543372/79441018-60ff4c80-7fdf-11ea-856a-f76c24f1e218.png)
- If there _was_ an error during the latest validation, but the input changed since (_stale/validating_), this icon is shown:
![image](https://user-images.githubusercontent.com/543372/79441060-6c527800-7fdf-11ea-8535-de3c6f5758e9.png)
- If the last state was _correct_ but the input changed since, we don't show anything. A flashing icon would look bad IMO, so unless we add an icon for the valid state, this is probably nicer behavior.

I also fixed the vertical alignment of the icons so they are always in the middle.

## TypeScript changes

### `useValidateSchema`

`useValidateSchema` now returns an object instead of a single string array. This is not a big deal as the hook is considered internal, I guess.

### `FormButton`

There are some "breaking" changes here. They improve type safety, neither affects `platform-internal`, and this is `beta`, but still, let me know if you don't like it here.

- `IFormButtonProps`, aka `IFormButton` is not exported anymore. There's no point. 
  
  ```typescript
  type IFormButtonProps = React.ComponentProps<typeof FormButton>;
  ```
  and that's it, if anyone needs it. But we never used it in the first place.
- `FormButton` is generic. This is to remove the `any`s from the props, and to make sure that `typeof data` aligns with the schema. I can't do `<FormButton data="abc" schema={yup.number()}/>` anymore.
- `FormButton`'s `onClick` lost it's attribute. It would not work with the new typing, and also there's absolutely 0 point, as the parameter passed was always simply the `data` prop back.