### PR TITLE
fix: object validation for `useValidateSchema` & story for FormButton

### DIFF
--- a/src/__stories__/FormButton/index.tsx
+++ b/src/__stories__/FormButton/index.tsx
@@ -1,0 +1,57 @@
+import { FormGroup } from '@blueprintjs/core';
+import { storiesOf } from '@storybook/react';
+import * as React from 'react';
+import * as yup from 'yup';
+
+import { FormButton } from '../../FormButton';
+import { FormInput } from '../../FormInput';
+
+storiesOf('FormButton', module).add('validation', () => {
+  return (
+    <div className="p-40">
+      <ExampleContainer />
+    </div>
+  );
+});
+
+const ExampleContainer: React.FC = () => {
+  const [field1, setField1] = React.useState('');
+  const [field2, setField2] = React.useState('');
+
+  const totalData = React.useMemo(
+    () => ({
+      field1,
+      field2,
+    }),
+    [field1, field2],
+  );
+
+  return (
+    <div>
+      <FormGroup label="Field 1 - Name">
+        <FormInput
+          value={field1}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setField1(e.currentTarget.value)}
+          schema={field1Schema}
+        />
+      </FormGroup>
+      <FormGroup label="Field 2 - Email">
+        <FormInput
+          value={field2}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setField2(e.currentTarget.value)}
+          schema={field2Schema}
+        />
+      </FormGroup>
+      <FormButton onClick={() => alert('hey')} data={totalData} schema={totalSchema}>
+        Submit
+      </FormButton>
+    </div>
+  );
+};
+
+const field1Schema = yup.string().min(2, 'Min 2 characters');
+const field2Schema = yup.string().email();
+const totalSchema = yup.object().shape({
+  field1: field1Schema,
+  field2: field2Schema,
+});

--- a/src/__stories__/index.ts
+++ b/src/__stories__/index.ts
@@ -2,6 +2,7 @@ import './Docs';
 import './Checkbox';
 import './Code';
 import './Dropdown';
+import './FormButton';
 import './FormInput';
 import './AutoSizer';
 import './ScrollContainer';

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -17,7 +17,7 @@ export function useValidateSchema<T>(
       return;
     }
     schema
-      .validate(value, { strict: true, abortEarly }) // to avoid taking a useEffect dependency on validateOpts that is an object
+      .validate(value, { strict: true, abortEarly: abortEarly ?? true }) // to avoid taking a useEffect dependency on validateOpts that is an object
       .then(() => {
         setErrors(noError);
       })

--- a/src/_hooks/useValidateSchema.ts
+++ b/src/_hooks/useValidateSchema.ts
@@ -7,7 +7,7 @@ const unknownError = ['Unknown error'];
 export function useValidateSchema<T>(
   schema?: yup.Schema<T>,
   value?: T,
-  { abortEarly, recursive }: yup.ValidateOptions = {},
+  { abortEarly }: yup.ValidateOptions = {},
 ): string[] {
   const [errors, setErrors] = React.useState<string[]>(noError);
 
@@ -17,14 +17,14 @@ export function useValidateSchema<T>(
       return;
     }
     schema
-      .validate(value, { strict: true, abortEarly, recursive }) // to avoid taking a useEffect dependency on validateOpts that is an object
+      .validate(value, { strict: true, abortEarly }) // to avoid taking a useEffect dependency on validateOpts that is an object
       .then(() => {
         setErrors(noError);
       })
       .catch(e => {
         setErrors(e.errors || unknownError);
       });
-  }, [schema, value, abortEarly, recursive]);
+  }, [schema, value, abortEarly]);
 
   return errors;
 }


### PR DESCRIPTION
Currently `FormButton` does not work with object `data` and `schema`, which makes it quite useless.

The problem is that for some reason if we pass a configuration object to `yup`, even `undefined` properties of said object override defaults. (They act as false.) 

This means we were effectively always passing `abortEarly: false, recursive: false`. I fixed the default for `abortEarly`, and I removed the option for `recursive` as neither did we ever use it, nor can I think of a situation where it can be useful. This is an internal hook, so the change is not breaking.

I also added a story to highlight the problem, that takes up the majority of lines added in this PR.