### PR TITLE
fix: dark theme CodeEditor

### DIFF
--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -24,8 +24,9 @@
   hyphens: none;
   direction: ltr;
 
-  .bp3-dark,
-  data[theme='dark'] & {
+
+  .#{$ns}-dark &,
+  [data-theme="dark"] & {
     @include darkCodeTheme;
   }
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/587740/79522745-7f3e6a00-802a-11ea-8d29-5c915779f07b.png)

After:
![image](https://user-images.githubusercontent.com/587740/79522785-9bdaa200-802a-11ea-9c1f-9a7a01cddc98.png)
