### PR TITLE
Fix: scrollbar flicker

### DIFF
--- a/src/ScrollContainer/index.tsx
+++ b/src/ScrollContainer/index.tsx
@@ -142,7 +142,11 @@ const ScrollContainer = React.forwardRef<ScrollbarRefInstance, IScrollContainer>
     if (autosize) {
       return (
         <AutoSizer className="relative">
-          {({ height, width }) => <div style={{ height, width }}>{ScrollElem}</div>}
+          {({ height, width }) => (
+            <div style={{ height: height - 1, width: width - 1 }} className="overflow-hidden">
+              {ScrollElem}
+            </div>
+          )}
         </AutoSizer>
       );
     }


### PR DESCRIPTION
Fixes stoplightio/platform-internal#457

In my experience (I have encountered such situation in an earlier project) the flickering occurs because of some rounding errors. The exact numbers are probably off, but here is roughly what happens:

1. There's about a let's say *999.5px* wide area remaining for the `AutoSizer` to fill.
2. The `AutoSizer` rounds this up, reports a width of *1000px*.
3. The `AutoSizer`'s content is stretched out to *1000px*. 
4. The browser recognizes that those 1000 pixels aren't going to exactly fit (there's only *999.5px* of space), so it introduces a scrollbar.
5. Introducing the scrollbar means there's now less space for the `AutoSizer`, which then recalculates it's size.
6. This time it happens to round in the "correct" dimension, so the content is resized to *999px*.
7. The browser recognizes that all content fits just fine so there's no need for the scrollbar and removes it.
8. Jump to step 1.

This PR solves the problem in a very simple way: it makes the `ScrollContainer` defensively assume there's 1px less space available than what the `AS` reports.

Other possible solutions include wrapping the entire `AutoSizer` into an `overflow: hidden` container, but then we need to make sure autosizing works fine (`height: 100%; width: 100%`, etc.) which is probably more dangerous than this change.