### PR TITLE
feat: properly type RowRenderer

### DIFF
--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -35,16 +35,24 @@ export type ITableOfContentsLink = TableOfContentsItem & {
   isExternalLink?: boolean;
 };
 
+export type RowRendererType<T extends TableOfContentsItem> = (props: {
+  item: T;
+  key: number | string;
+  getProps: (
+    node: ITableOfContentsNode,
+  ) => {
+    onClick: ((e: React.MouseEvent<any, MouseEvent>) => void) | undefined;
+    style: React.CSSProperties;
+    className: string;
+  };
+  DefaultRow: React.FC<ITableOfContentsNode<T>>;
+}) => React.ReactElement | undefined;
+
 export interface ITableOfContents<T extends TableOfContentsItem = TableOfContentsItem> {
   contents: T[];
 
   // Caller should return undefined if they don't want to provide custom elem
-  rowRenderer?: (props: {
-    item: T;
-    key: number | string;
-    getProps: typeof computeTableOfContentsItemProps;
-    DefaultRow: React.FC<ITableOfContentsNode<T>>;
-  }) => React.ReactElement | undefined;
+  rowRenderer?: RowRendererType<T>;
 
   // Padding that will be used for (default: 10)
   padding?: string;
@@ -232,12 +240,12 @@ interface ITableOfContentsNode<T extends TableOfContentsItem = TableOfContentsIt
   onClick?: (e: React.MouseEvent<any, MouseEvent>) => void;
 }
 
-const computeTableOfContentsItemProps = ({
+const computeTableOfContentsItemProps = <T extends TableOfContentsItem>({
   item,
   isSelected: _isSelected,
   isActive: _isActive,
   onClick,
-}: ITableOfContentsNode) => {
+}: ITableOfContentsNode<T>) => {
   const depth = item.depth || 0;
   const isChild = item.type !== 'group' && depth > 0;
   const isGroup = item.type === 'group';


### PR DESCRIPTION
hint: It's still a mess

This is relevant because of https://github.com/stoplightio/platform-internal/issues/2527

That error is a result of us using an any-typed `rowRenderer`:
```ts
const rowRenderer = React.useCallback<any>(
```
https://github.com/stoplightio/elements/blob/beta/src/components/TableOfContents/index.tsx#L19

It turns out it is incredibly hard to correctly get the type of the callback, and having that `getProps: typeof computeTableOfContentsItemProps` is also prone to accidental breaking changes.

I pulled out the type of the rowRenderer to an explicitly defined type, and inlined the `typeof computeTableOfContentsItemProps` definition to make it a stable API.

IMO this renderer signature is still a mess, but I intended not to change it in this PR, just type it more explicitly.