### PR TITLE
feat(table-of-contents): add data-test attribute

### DIFF
--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -50,6 +50,11 @@ export interface ITableOfContents<T extends TableOfContentsItem = TableOfContent
   padding?: string;
   className?: string;
 
+  /**
+   * HTML data-test attribute to be set on the container div.
+   */
+  'data-test': string;
+
   // force items to render with active or selected if either is true.
   // for example if forceStateStyle=active, then if an item isSelected or isActive is true, will render with active styling
   forceStateStyle?: 'active' | 'selected';
@@ -167,6 +172,7 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
 
 export function TableOfContents<T extends TableOfContentsItem = TableOfContentsItem>({
   className,
+  'data-test': dataTest,
   padding = '4',
   title,
   isOpen = false,
@@ -198,7 +204,7 @@ export function TableOfContents<T extends TableOfContentsItem = TableOfContentsI
         />
       )}
 
-      <div className={containerClassName}>
+      <div className={containerClassName} data-test={dataTest}>
         {renderWithScroll && withScroller ? <ScrollContainer>{toc}</ScrollContainer> : toc}
       </div>
     </>

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -53,7 +53,7 @@ export interface ITableOfContents<T extends TableOfContentsItem = TableOfContent
   /**
    * HTML data-test attribute to be set on the container div.
    */
-  'data-test': string;
+  'data-test'?: string;
 
   // force items to render with active or selected if either is true.
   // for example if forceStateStyle=active, then if an item isSelected or isActive is true, will render with active styling


### PR DESCRIPTION
Related to stoplightio/platform-internal#2527

While the PR for that issue (stoplightio/platform-internal#2537) was in review, a new prop was added to the TableOfContents component in `ninja`. stoplightio/platform-internal#2332

In this PR I migrate that prop too.

Two changes I made:
- I named the prop `data-test` instead of `dataTest` so it is consistent with the native `data-test` prop on HTML elements.
- I added a short documentation sentence.

When I pull this into stoplightio/platform-internal#2537 I'll update the e2e test to reflect the prop name change.