### PR TITLE
feat(Table of Contents): auto expand to show active items

### DIFF
--- a/src/__fixtures__/table-of-contents/studio.ts
+++ b/src/__fixtures__/table-of-contents/studio.ts
@@ -53,10 +53,11 @@ export const studioContents: ITableOfContentsLink[] = [
     to: '/reference/petstore/openapi.v1.yaml/components/schemas/Pets',
   },
   {
-    name: 'Info for a specific pet',
+    name: 'Info for a specific pet [active item]',
     depth: 1,
     type: 'item',
     to: '/reference/petstore/openapi.v1.yaml/paths/~1pets~1{petId}/get',
+    isActive: true,
   },
   {
     name: 'List all pets',


### PR DESCRIPTION
The `TableOfContents` component will auto expand and scroll to make sure it shows items that are `isActive: true`, by default.

Will be used to resolve stoplightio/platform-internal#2308

The expand part works, scroll functionality to be done.