### PR TITLE
fix(code-viewer): reduce initial layout shift

### DIFF
--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -24,7 +24,6 @@
       margin-left: -$line-sidebar-width;
       padding-left: $line-sidebar-width;
       position: relative;
-      width: calc(100% - #{line-sidebar-width});
       display: block;
 
       &::before {

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -11,15 +11,20 @@
   }
 
   &--line-numbers {
+    $line-sidebar-width: 45px;
+
+    padding-left: $line-sidebar-width;
+
     textarea {
       // Need to use margin here since CodeEditor supports padding: https://github.com/stoplightio/ui-kit/blob/fd1334753a22d527b803b8554bc51761c348d319/src/CodeEditor/index.tsx#L13
       margin-left: 35px !important;
     }
 
     .line-number {
-      padding-left: 45px;
+      margin-left: -$line-sidebar-width;
+      padding-left: $line-sidebar-width;
       position: relative;
-      width: calc(100% - 45px);
+      width: calc(100% - #{line-sidebar-width});
       display: block;
 
       &::before {


### PR DESCRIPTION

This one has been caught by Marc.
before:
![before](https://user-images.githubusercontent.com/9273484/89078491-cc99d980-d384-11ea-92b2-d69f4f054417.gif)
after:
![after](https://user-images.githubusercontent.com/9273484/89078427-b2f89200-d384-11ea-8ff3-00648bf1fbe8.gif)
