### PR TITLE
feat(code-viewer): scroll overscan

### DIFF
--- a/src/CodeViewer/components/BlockCodeViewer/SingleCodeBlock.tsx
+++ b/src/CodeViewer/components/BlockCodeViewer/SingleCodeBlock.tsx
@@ -23,7 +23,7 @@ export const SingleCodeBlock: React.FC<IBlockProps> = ({
   observer,
 }) => {
   const [markup, setMarkup] = React.useState<ReactNode[]>();
-  const [isVisible, setIsVisible] = React.useState(index === 0); // the assumption is that we always start with scrollTop = 0
+  const [isVisible, setIsVisible] = React.useState(false);
 
   React.useEffect(() => {
     return observer.addListener(index, () => {

--- a/src/CodeViewer/components/BlockCodeViewer/consts.ts
+++ b/src/CodeViewer/components/BlockCodeViewer/consts.ts
@@ -1,1 +1,2 @@
-export const SINGLE_LINE_SIZE = 24;
+export const SINGLE_LINE_SIZE = 24; // this has to be on par with an actual line of element as rendered in browser
+export const LINES_OVER_SCAN = 10;

--- a/src/CodeViewer/components/BlockCodeViewer/consts.ts
+++ b/src/CodeViewer/components/BlockCodeViewer/consts.ts
@@ -1,2 +1,1 @@
 export const SINGLE_LINE_SIZE = 24; // this has to be on par with an actual line of element as rendered in browser
-export const LINES_OVER_SCAN = 10;


### PR DESCRIPTION
This could have been done as a part of https://github.com/stoplightio/ui-kit/pull/179, but 179 is a no-brainer, while this one might potentially break something (it shouldn't, though).
It also improves support for initial scrollTop scenario.
