### PR TITLE
fix(table-of-contents): apply maxWidth to selectFilter

### DIFF
--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -214,6 +214,7 @@ export function TableOfContents<T extends TableOfContentsItem = TableOfContentsI
             className={cn(`m-${padding}`, { 'mr-0': hasFilter })}
           >
             <Button
+              className="w-48 truncate"
               text={getActiveItem()?.name ?? selectFilter.initialContent ?? 'Fetching...'}
               alignText="left"
               rightIcon="caret-down"

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -214,7 +214,8 @@ export function TableOfContents<T extends TableOfContentsItem = TableOfContentsI
             className={cn(`m-${padding}`, { 'mr-0': hasFilter })}
           >
             <Button
-              className="w-48 truncate"
+              className="truncate"
+              style={{ maxWidth: '12rem' }}
               text={getActiveItem()?.name ?? selectFilter.initialContent ?? 'Fetching...'}
               alignText="left"
               rightIcon="caret-down"


### PR DESCRIPTION
Table of Contents `selectFilter`:

Sets width for select and truncates large text instead of allowing it to wrap.

**Screenshots**

Currently in production:
<img width="887" alt="Screenshot 2020-08-03 at 3 37 16 PM" src="https://user-images.githubusercontent.com/17899454/89174480-5ae9a780-d59f-11ea-8021-0b2829a01171.png">

After:
<img width="977" alt="Screenshot 2020-08-03 at 3 38 35 PM" src="https://user-images.githubusercontent.com/17899454/89174521-6d63e100-d59f-11ea-9d79-6be9aafa27a1.png">
