### PR TITLE
feat(code-viewer): align line numbers to the right

### DIFF
--- a/src/CodeViewer/components/BlockCodeViewer/BlockCodeViewer.tsx
+++ b/src/CodeViewer/components/BlockCodeViewer/BlockCodeViewer.tsx
@@ -20,6 +20,7 @@ const BlockCodeViewer: React.FC<IBlockCodeViewerProps> = ({ className, language,
   const [maxLines, setMaxLines] = React.useState<number | null>(null);
   const observerRef = React.useRef(new ObservableSet());
   const slicedBlocks = useSlicedBlocks(value, maxLines === null ? null : Math.max(0, maxLines - 1));
+  const linesNo = String(slicedBlocks !== null && maxLines !== null ? slicedBlocks.length * maxLines : 0).length;
 
   React.useLayoutEffect(() => {
     if (nodeRef.current !== null) {
@@ -89,7 +90,7 @@ const BlockCodeViewer: React.FC<IBlockCodeViewerProps> = ({ className, language,
     <pre
       ref={nodeRef}
       className={cn(Classes.CODE_EDITOR, className, `language-${language || 'unknown'}`, {
-        [`${Classes.CODE_EDITOR}--line-numbers`]: showLineNumbers,
+        [`${Classes.CODE_EDITOR}--line-numbers ${Classes.CODE_EDITOR}--line-numbers--${linesNo}`]: showLineNumbers,
       })}
       {...rest}
     >

--- a/src/CodeViewer/components/BlockCodeViewer/BlockCodeViewer.tsx
+++ b/src/CodeViewer/components/BlockCodeViewer/BlockCodeViewer.tsx
@@ -20,7 +20,9 @@ const BlockCodeViewer: React.FC<IBlockCodeViewerProps> = ({ className, language,
   const [maxLines, setMaxLines] = React.useState<number | null>(null);
   const observerRef = React.useRef(new ObservableSet());
   const slicedBlocks = useSlicedBlocks(value, maxLines === null ? null : Math.max(0, maxLines - 1));
-  const linesNo = String(slicedBlocks !== null && maxLines !== null ? slicedBlocks.length * maxLines : 0).length;
+  const lineNumberCharacterCount = String(
+    slicedBlocks !== null && maxLines !== null ? slicedBlocks.length * maxLines : 0,
+  ).length;
 
   React.useLayoutEffect(() => {
     if (nodeRef.current !== null) {
@@ -90,7 +92,7 @@ const BlockCodeViewer: React.FC<IBlockCodeViewerProps> = ({ className, language,
     <pre
       ref={nodeRef}
       className={cn(Classes.CODE_EDITOR, className, `language-${language || 'unknown'}`, {
-        [`${Classes.CODE_EDITOR}--line-numbers ${Classes.CODE_EDITOR}--line-numbers--${linesNo}`]: showLineNumbers,
+        [`${Classes.CODE_EDITOR}--line-numbers ${Classes.CODE_EDITOR}--line-numbers--${lineNumberCharacterCount}`]: showLineNumbers,
       })}
       {...rest}
     >

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -11,18 +11,29 @@
   }
 
   &--line-numbers {
-    $line-sidebar-width: 45px;
-
-    padding-left: $line-sidebar-width;
+    $line-sidebar-width: 15px;
 
     textarea {
       // Need to use margin here since CodeEditor supports padding: https://github.com/stoplightio/ui-kit/blob/fd1334753a22d527b803b8554bc51761c348d319/src/CodeEditor/index.tsx#L13
       margin-left: 35px !important;
     }
 
+    @for $i from 1 through 6 {
+      &--#{$i} {
+        padding-left: $line-sidebar-width * $i;
+
+        .line-number {
+          margin-left: -$line-sidebar-width * $i;
+          padding-left: $line-sidebar-width * $i;
+
+          &::before {
+            width: $line-sidebar-width * $i;
+          }
+        }
+      }
+    }
+
     .line-number {
-      margin-left: -$line-sidebar-width;
-      padding-left: $line-sidebar-width;
       position: relative;
       display: block;
 
@@ -30,9 +41,11 @@
         content: attr(data-node-index);
         display: inline-block;
         position: absolute;
-        left: 5px;
+        left: 0;
+        padding-right: $line-sidebar-width;
         opacity: 0.4;
         user-select: none;
+        text-align: right;
       }
     }
   }

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -11,7 +11,7 @@
   }
 
   &--line-numbers {
-    $line-sidebar-width: 15px;
+    $line-number-char-width: 15px;
 
     textarea {
       // Need to use margin here since CodeEditor supports padding: https://github.com/stoplightio/ui-kit/blob/fd1334753a22d527b803b8554bc51761c348d319/src/CodeEditor/index.tsx#L13
@@ -20,14 +20,14 @@
 
     @for $i from 1 through 6 {
       &--#{$i} {
-        padding-left: $line-sidebar-width * $i;
+        padding-left: ($line-number-char-width * $i) + 15px;
 
         .line-number {
-          margin-left: -$line-sidebar-width * $i;
-          padding-left: $line-sidebar-width * $i;
+          margin-left: -$line-number-char-width * $i;
+          padding-left: $line-number-char-width * $i;
 
           &::before {
-            width: $line-sidebar-width * $i;
+            width: $line-number-char-width * $i;
           }
         }
       }
@@ -42,7 +42,7 @@
         display: inline-block;
         position: absolute;
         left: 0;
-        padding-right: $line-sidebar-width;
+        padding-right: $line-number-char-width;
         opacity: 0.4;
         user-select: none;
         text-align: right;


### PR DESCRIPTION
Instead of pre-defined value, let's actually adjust the width according to the number of digits

Before:
![image](https://user-images.githubusercontent.com/9273484/89228942-d455ba00-d5e0-11ea-90fd-ac88061e3894.png)
![image](https://user-images.githubusercontent.com/9273484/89228962-dc155e80-d5e0-11ea-80ab-f74eac848240.png)
![image](https://user-images.githubusercontent.com/9273484/89228976-e0da1280-d5e0-11ea-89cd-7c66d2b086e5.png)
![image](https://user-images.githubusercontent.com/9273484/89228998-ed5e6b00-d5e0-11ea-8bcd-fd5e5f3d25b3.png)


After:
![image](https://user-images.githubusercontent.com/9273484/89228838-9fe1fe00-d5e0-11ea-9de0-8c4e9c485ecf.png)
![image](https://user-images.githubusercontent.com/9273484/89228851-a6707580-d5e0-11ea-980a-ecfb56de6b8c.png)
![image](https://user-images.githubusercontent.com/9273484/89228868-ae301a00-d5e0-11ea-8fff-ebe945c9088f.png)
![image](https://user-images.githubusercontent.com/9273484/89228876-b2f4ce00-d5e0-11ea-87c1-19346fec34b6.png)
![image](https://user-images.githubusercontent.com/9273484/89228898-bc7e3600-d5e0-11ea-980f-08166cacada6.png)
![image](https://user-images.githubusercontent.com/9273484/89228919-c4d67100-d5e0-11ea-9a5e-0f055af13dce.png)
