### PR TITLE
feat: toc external link

### DIFF
--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -140,7 +140,7 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
         return (
           <RowComponent
             key={index}
-            item={item}
+            item={isExternalLink(item) ? { ...item, isExternalLink: true } : item}
             index={index}
             isExpanded={isExpanded}
             toggleExpanded={toggleExpandedFunctions[index]}
@@ -345,4 +345,12 @@ function findAncestorIndices(currentDepth: number, precedingContents: TableOfCon
     ...findAncestorIndices(precedingContents[parentIndex].depth ?? 0, precedingContents.slice(0, parentIndex)),
     parentIndex,
   ];
+}
+
+function isExternalLink(item: TableOfContentsItem): boolean {
+  return isTableOfContentsLink(item) && item.to !== void 0 && /^(http|#|mailto)/.test(item.to);
+}
+
+function isTableOfContentsLink(item: TableOfContentsItem): item is ITableOfContentsLink {
+  return 'to' in item;
 }


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/3949
Adds optional `isExternalLink` property to ToC link items.
This could be done in Elements though there we'd have to handle both toc tree and branch nodes computing functions.