### PR TITLE
fix(code-viewer): use useEffect instead of useLayoutEffect

### DIFF
--- a/src/CodeViewer/components/BlockCodeViewer/BlockCodeViewer.tsx
+++ b/src/CodeViewer/components/BlockCodeViewer/BlockCodeViewer.tsx
@@ -29,7 +29,7 @@ const BlockCodeViewer: React.FC<IBlockCodeViewerProps> = ({ className, language,
     slicedBlocks !== null && maxLines !== null ? slicedBlocks.length * maxLines : 0,
   ).length;
 
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     if (nodeRef.current !== null) {
       setMaxLines(calculateMaxLines(window.innerHeight)); // we have to use window here, as element may not ave any height at this time
     }


### PR DESCRIPTION
`useLayoutEffect` is not supported by SSR.
Swapping `useLayoutEffect` with `useEffect` improves the rendering of CodeViewer on sites that use SSR.
The regular usage does not seem to be notably affected by this change.