### PR TITLE
feat(code-viewer): animated transition from plain to highlighted

### DIFF
--- a/src/CodeViewer/components/BlockCodeViewer/SingleCodeBlock.tsx
+++ b/src/CodeViewer/components/BlockCodeViewer/SingleCodeBlock.tsx
@@ -84,7 +84,7 @@ export const SingleCodeBlock: React.FC<IBlockProps> = ({
   }, [isVisible, lineNumber, value, language, showLineNumbers]);
 
   if (markup !== void 0) {
-    return markup as any;
+    return <>{markup}</>;
   }
 
   return <div ref={nodeRef}>{value}</div>;

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -66,8 +66,6 @@ $line-padding-left: 10px;
 
   // Tokens
   .token {
-    animation: set-color 0.3s ease-out;
-
     &.important,
     &.bold {
       font-weight: bold;
@@ -225,6 +223,10 @@ $line-padding-left: 10px;
 }
 
 .CodeViewer {
+  .token {
+    animation: set-color 0.3s ease-out;
+  }
+
   &--line-numbers {
     @for $i from 1 through 6 {
       &--#{$i} {

--- a/src/styles/components/Code/_base.scss
+++ b/src/styles/components/Code/_base.scss
@@ -5,6 +5,13 @@
 $line-number-char-width: 10px;
 $line-padding-left: 10px;
 
+@keyframes set-color {
+  0% {
+    color: inherit;
+  }
+}
+
+
 .CodeEditor,
 .CodeViewer {
   @include lightCodeTheme;
@@ -59,6 +66,8 @@ $line-padding-left: 10px;
 
   // Tokens
   .token {
+    animation: set-color 0.3s ease-out;
+
     &.important,
     &.bold {
       font-weight: bold;


### PR DESCRIPTION
Followup to #192 and stoplightio/platform-internal#4086

## Summary

Animates the transition from plain text view to highlighted view.

## Details
When first rendering the CodeViewer it does not perform syntax highlighting.

To optimize performance highlighting happens after rendering in a `useEffect` hook. This causes a flicker when the coloring is finally applied to the text. This is especially noticable when the initial render is performed server-side.

This fix smoothens out the process using a short (0.3s) animation to introduce the color.

### Why not inside CodeEditor?

The library CodeEditor is using is probably missing some keys, which makes every token `div` remounted on change (which happens quite often in an editor). This causes repeated animations.

### Extra

Fixed that ugly `as any` cast.

## Demo

Check out the codeviewer storybooks.