### PR TITLE
feat: bump fontawesome types to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@blueprintjs/core": "^3.29.0",
     "@blueprintjs/icons": "^3.19.0",
     "@blueprintjs/select": "^3.13.4",
-    "@fortawesome/fontawesome-common-types": "^0.2.29",
+    "@fortawesome/fontawesome-common-types": "^0.2.31",
     "classnames": "^2.2.6",
     "prismjs": "^1.20.0",
     "react-input-autosize": "^2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,10 +1174,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@fortawesome/fontawesome-common-types@^0.2.29":
-  version "0.2.29"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.29.tgz#e1a456b643237462d390304cab6975ff3fd68397"
-  integrity sha512-cY+QfDTbZ7XVxzx7jxbC98Oxr/zc7R2QpTLqTxqlfyXDrAJjzi/xUIqAUsygELB62JIrbsWxtSRhayKFkGI7MA==
+"@fortawesome/fontawesome-common-types@^0.2.31":
+  version "0.2.31"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.31.tgz#f15a39e5ab4e5dfda0717733bcacb9580e666ad9"
+  integrity sha512-xfnPyH6NN5r/h1/qDYoGB0BlHSID902UkQzxR8QsoKDh55KAPr8ruAoie12WQEEQT8lRE2wtV7LoUllJ1HqCag==
 
 "@iarna/cli@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
To remove version conflict and resolution in https://github.com/stoplightio/elements/pull/607

Only types changed.