### PR TITLE
feat: Display endpoint method and icons for schema and API

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,3 @@
+<!-- .storybook/preview-head.html -->
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css">

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -110,16 +110,14 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
   // an array of functions. Invoking the N-th function toggles the expanded flag on the N-th content item
   const toggleExpandedFunctions = React.useMemo(() => {
     return range(contents.length).map(i => () => {
-      let childrenToCollapse = {};
-      if (expanded[i]) {
-        const item = contents[i];
-        const children = findDescendantIndices(item.depth ?? 0, i, contents.slice(i + 1));
-        childrenToCollapse = children.reduce((obj, index) => {
-          obj[index] = false;
-          return obj;
-        }, {});
-      }
       setExpanded(current => {
+        let childrenToCollapse = {};
+        if (current[i]) {
+          const item = contents[i];
+          const children = findDescendantIndices(item.depth ?? 0, i, contents.slice(i + 1));
+          childrenToCollapse = Object.fromEntries(children.map(i => [i, false]));
+        }
+
         return {
           ...current,
           [i]: !current[i],
@@ -128,7 +126,7 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
       });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [contents, contents.length, expanded]);
+  }, [contents, contents.length]);
 
   // expand ancestors of active items by default
   React.useEffect(() => {
@@ -347,7 +345,7 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
           {actionElem}
           {item.iconPosition === 'right' && iconElem}
           {isGroup && (
-            <div onClick={() => isGroupItem && toggleExpanded()} className="px-2">
+            <div onClick={isGroupItem ? toggleExpanded : undefined} className="px-2">
               <FAIcon className="TableOfContentsItem__icon" icon={isExpanded ? 'chevron-down' : 'chevron-right'} />
             </div>
           )}

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -310,6 +310,7 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
     <FAIcon
       className={cn('fa-fw', {
         'mr-3': item.iconPosition !== 'right',
+        'mx-1': item.iconPosition === 'right',
         'text-blue-6': isSelected,
         [`text-${item.iconColor}`]: item.iconColor,
         'bp3-skeleton': item.showSkeleton,

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -19,6 +19,8 @@ export type TableOfContentsItem = {
   icon?: FAIconProp;
   activeIcon?: FAIconProp;
   iconColor?: string;
+  iconPosition?: 'left' | 'right';
+  textIcon?: string;
   isLoading?: boolean;
   isDisabled?: boolean;
   showSkeleton?: boolean;
@@ -203,6 +205,7 @@ export function TableOfContents<T extends TableOfContentsItem = TableOfContentsI
 
 function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggleExpanded }: RowComponentProps<T>) {
   const isGroup = item.type === 'group';
+  const isGroupItem = isGroup && isTableOfContentsLink(item);
   const isChild = item.type !== 'group' && (item.depth ?? 0) > 0;
   const isDivider = item.type === 'divider';
   const showSkeleton = item.showSkeleton;
@@ -239,7 +242,7 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
           return;
         }
 
-        if (!isGroup) return;
+        if (!isGroup || isGroupItem) return;
 
         e.preventDefault();
         toggleExpanded();
@@ -290,6 +293,26 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
     />
   ) : null;
 
+  const iconElem = icon ? (
+    <FAIcon
+      className={cn('fa-fw', {
+        'mr-3': item.iconPosition !== 'right',
+        'text-blue-6': isSelected,
+        [`text-${item.iconColor}`]: item.iconColor,
+        'bp3-skeleton': item.showSkeleton,
+      })}
+      icon={icon}
+    />
+  ) : item.textIcon ? (
+    <div
+      className={cn('text-right rounded px-1 text-xs uppercase', {
+        [`text-${item.iconColor}`]: item.iconColor,
+      })}
+    >
+      {item.textIcon}
+    </div>
+  ) : null;
+
   return (
     <div
       onClick={onClick}
@@ -299,12 +322,7 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
     >
       <div className={cn('-ml-px', innerClassName, { 'opacity-75': isDisabled })}>
         <div className="flex flex-row items-center">
-          {icon && (
-            <FAIcon
-              className={cn('mr-3 fa-fw', { 'text-blue-6': isSelected, 'bp3-skeleton': item.showSkeleton })}
-              icon={icon}
-            />
-          )}
+          {item.iconPosition !== 'right' && iconElem}
 
           <span className={cn('TableOfContentsItem__name flex-1 truncate', { 'bp3-skeleton': item.showSkeleton })}>
             {item.name}
@@ -313,11 +331,11 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
           {item.meta && <span className="text-sm text-left text-gray font-medium">{item.meta}</span>}
           {loadingElem}
           {actionElem}
+          {item.iconPosition === 'right' && iconElem}
           {isGroup && (
-            <FAIcon
-              className="TableOfContentsItem__icon"
-              icon={['far', isExpanded ? 'chevron-down' : 'chevron-right']}
-            />
+            <div onClick={() => isGroupItem && toggleExpanded()} className="px-2">
+              <FAIcon className="TableOfContentsItem__icon" icon={isExpanded ? 'chevron-down' : 'chevron-right'} />
+            </div>
           )}
         </div>
         {item.footer}

--- a/src/__fixtures__/table-of-contents/tree.ts
+++ b/src/__fixtures__/table-of-contents/tree.ts
@@ -7,14 +7,19 @@ export const tree: ITableOfContentsLink[] = [
     type: 'divider',
   },
   {
-    name: 'Group',
+    name: 'Group with link',
     depth: 0,
     type: 'group',
+    to: '/path',
+    icon: 'cloud',
   },
   {
-    name: 'Nested Item',
+    name: 'Nested Item with text icon',
     depth: 1,
     type: 'item',
+    textIcon: 'ONE',
+    iconColor: 'red',
+    iconPosition: 'right',
   },
   {
     name: 'Nested Group',
@@ -30,6 +35,9 @@ export const tree: ITableOfContentsLink[] = [
     name: 'Nested Item',
     depth: 3,
     type: 'item',
+    textIcon: 'TWO',
+    iconColor: 'blue',
+    iconPosition: 'right',
   },
   {
     name: 'Nested Group',
@@ -40,5 +48,8 @@ export const tree: ITableOfContentsLink[] = [
     name: 'Nested Item',
     depth: 2,
     type: 'item',
+    textIcon: 'THREE',
+    iconColor: 'green',
+    iconPosition: 'left',
   },
 ];

--- a/src/__fixtures__/table-of-contents/tree.ts
+++ b/src/__fixtures__/table-of-contents/tree.ts
@@ -1,0 +1,44 @@
+import { ITableOfContentsLink } from '../../TableOfContents';
+
+export const tree: ITableOfContentsLink[] = [
+  {
+    name: 'Tree',
+    depth: 0,
+    type: 'divider',
+  },
+  {
+    name: 'Group',
+    depth: 0,
+    type: 'group',
+  },
+  {
+    name: 'Nested Item',
+    depth: 1,
+    type: 'item',
+  },
+  {
+    name: 'Nested Group',
+    depth: 1,
+    type: 'group',
+  },
+  {
+    name: 'Nested Group',
+    depth: 2,
+    type: 'group',
+  },
+  {
+    name: 'Nested Item',
+    depth: 3,
+    type: 'item',
+  },
+  {
+    name: 'Nested Group',
+    depth: 1,
+    type: 'group',
+  },
+  {
+    name: 'Nested Item',
+    depth: 2,
+    type: 'item',
+  },
+];

--- a/src/__stories__/TableOfContents/index.tsx
+++ b/src/__stories__/TableOfContents/index.tsx
@@ -4,6 +4,7 @@ import { storiesOf } from '@storybook/react';
 import * as React from 'react';
 
 import { studioContents } from '../../__fixtures__/table-of-contents/studio';
+import { tree } from '../../__fixtures__/table-of-contents/tree';
 import { DefaultRow, ITableOfContentsLink, RowComponentType, TableOfContents } from '../../TableOfContents';
 
 const styles = {
@@ -26,6 +27,13 @@ storiesOf('TableOfContents', module)
     return (
       <div style={styles}>
         <TableOfContents className="h-full" contents={studioContents} />
+      </div>
+    );
+  })
+  .add('nested tree', () => {
+    return (
+      <div style={styles}>
+        <TableOfContents className="h-full" contents={tree} />
       </div>
     );
   })


### PR DESCRIPTION
Needed by https://github.com/stoplightio/elements/issues/639

Changes:
- fixes collapsing all descendant children nodes when toggling parent (nested nodes remained open - I've added a simple story for that)
- adds toc item icons positioning (we need to have them on both sides)
- allows using text labels instead of icons (i.e. for oas operation labels)
- splits group items containing `to` property so they can have both actions handled

~~Note: note sure if we should use paid FA icons here (as in original issue). IIRC elements were supposed to use free version which leaves platform without a choice.~~

![Peek 2020-11-16 04-44](https://user-images.githubusercontent.com/14196079/99210602-85feac80-27c6-11eb-8fcb-8a7b06733195.gif)
