### PR TITLE
feat: toc start expanded

### DIFF
--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -106,7 +106,10 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
   rowComponent: RowComponent = DefaultRow,
   rowComponentExtraProps,
 }: Pick<ITableOfContents<T, E>, 'className' | 'contents' | 'rowComponent' | 'rowComponentExtraProps'>) {
-  const [expanded, setExpanded] = React.useState({});
+  const [expanded, setExpanded] = React.useState(() => {
+    const itemsToExpand = contents.filter(item => item.startExpanded);
+    return Object.fromEntries(itemsToExpand.map(item => [contents.indexOf(item), true]));
+  });
 
   // an array of functions. Invoking the N-th function toggles the expanded flag on the N-th content item
   const toggleExpandedFunctions = React.useMemo(() => {
@@ -128,21 +131,6 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contents, contents.length]);
-
-  // expand items marked as initially expanded and its children
-  React.useEffect(() => {
-    const itemsToExpand = contents.filter(item => item.startExpanded);
-    const childrenToExpand = flatMap(itemsToExpand, item =>
-      findDescendantIndices(item.depth ?? 0, contents.indexOf(item), contents.slice(contents.indexOf(item) + 1)),
-    );
-
-    setExpanded(current => ({
-      ...current,
-      ...Object.fromEntries(itemsToExpand.map(index => [index, true])),
-      ...Object.fromEntries(childrenToExpand.map(index => [index, true])),
-    }));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // expand ancestors of active items by default
   React.useEffect(() => {

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -24,6 +24,7 @@ export type TableOfContentsItem = {
   isLoading?: boolean;
   isDisabled?: boolean;
   showSkeleton?: boolean;
+  startExpanded?: boolean;
   action?: {
     icon?: FAIconProp;
     name?: string;
@@ -127,6 +128,21 @@ function TableOfContentsInner<T extends TableOfContentsItem = TableOfContentsIte
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contents, contents.length]);
+
+  // expand items marked as initially expanded and its children
+  React.useEffect(() => {
+    const itemsToExpand = contents.filter(item => item.startExpanded);
+    const childrenToExpand = flatMap(itemsToExpand, item =>
+      findDescendantIndices(item.depth ?? 0, contents.indexOf(item), contents.slice(contents.indexOf(item) + 1)),
+    );
+
+    setExpanded(current => ({
+      ...current,
+      ...Object.fromEntries(itemsToExpand.map(index => [index, true])),
+      ...Object.fromEntries(childrenToExpand.map(index => [index, true])),
+    }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // expand ancestors of active items by default
   React.useEffect(() => {

--- a/src/__fixtures__/table-of-contents/tree.ts
+++ b/src/__fixtures__/table-of-contents/tree.ts
@@ -12,6 +12,7 @@ export const tree: ITableOfContentsLink[] = [
     type: 'group',
     to: '/path',
     icon: 'cloud',
+    startExpanded: true,
   },
   {
     name: 'Nested Item with text icon',


### PR DESCRIPTION
Needed by https://github.com/stoplightio/elements/pull/722

Adds support for initially expanded ToC items.