### PR TITLE
fix: missing caret icon in web components

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@blueprintjs/icons": "^3.19.0",
     "@blueprintjs/select": "^3.13.4",
     "@fortawesome/fontawesome-common-types": "^0.2.31",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
+    "@fortawesome/react-fontawesome": "^0.1.14",
     "classnames": "^2.2.6",
     "prismjs": "^1.20.0",
     "react-input-autosize": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@blueprintjs/icons": "^3.19.0",
     "@blueprintjs/select": "^3.13.4",
     "@fortawesome/fontawesome-common-types": "^0.2.31",
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "@fortawesome/react-fontawesome": "^0.1.14",
     "classnames": "^2.2.6",

--- a/src/TableOfContents/index.tsx
+++ b/src/TableOfContents/index.tsx
@@ -1,4 +1,6 @@
 import { Button, Drawer } from '@blueprintjs/core';
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import cn from 'classnames';
 import { flatMap, range } from 'lodash';
 import * as React from 'react';
@@ -350,7 +352,10 @@ function DefaultRowImpl<T extends TableOfContentsItem>({ item, isExpanded, toggl
           {item.iconPosition === 'right' && iconElem}
           {isGroup && (
             <div onClick={isGroupItem ? toggleExpanded : undefined} className="px-2">
-              <FAIcon className="TableOfContentsItem__icon" icon={isExpanded ? 'chevron-down' : 'chevron-right'} />
+              <FontAwesomeIcon
+                className="TableOfContentsItem__icon"
+                icon={isExpanded ? faChevronDown : faChevronRight}
+              />
             </div>
           )}
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1179,6 +1179,25 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.31.tgz#f15a39e5ab4e5dfda0717733bcacb9580e666ad9"
   integrity sha512-xfnPyH6NN5r/h1/qDYoGB0BlHSID902UkQzxR8QsoKDh55KAPr8ruAoie12WQEEQT8lRE2wtV7LoUllJ1HqCag==
 
+"@fortawesome/fontawesome-common-types@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
+  integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
+
+"@fortawesome/free-solid-svg-icons@^5.15.3":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz#52eebe354f60dc77e0bde934ffc5c75ffd04f9d8"
+  integrity sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
+"@fortawesome/react-fontawesome@^0.1.14":
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz#bf28875c3935b69ce2dc620e1060b217a47f64ca"
+  integrity sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@iarna/cli@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@iarna/cli/-/cli-1.2.0.tgz#0f7af5e851afe895104583c4ca07377a8094d641"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,6 +1184,13 @@
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
   integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
 
+"@fortawesome/fontawesome-svg-core@^1.2.35":
+  version "1.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz#85aea8c25645fcec88d35f2eb1045c38d3e65cff"
+  integrity sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
 "@fortawesome/free-solid-svg-icons@^5.15.3":
   version "5.15.3"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz#52eebe354f60dc77e0bde934ffc5c75ffd04f9d8"


### PR DESCRIPTION
Resolves: https://github.com/stoplightio/elements/issues/987

**Steps to reproduce in Elements**
1. Pull the branch and build the `ui-kit`
2. In `package.json` change `"@stoplight/ui-kit": "^3.0.0-beta.39"` to `"@stoplight/ui-kit": "file:../../../ui-kit/dist"`
3. Run `yarn upgrade @stoplight/ui-kit && yarn build`
4. In `github-api.html` change `<script>` and `<link>` so they point to `web-components/dist/elements.min.js` and `web-components/dist/elements.min.css`

## Before
<img src="https://user-images.githubusercontent.com/58433203/114388920-9e67cd00-9b94-11eb-95b9-909c51e2745f.png" width="300" />

## After
<img src="https://user-images.githubusercontent.com/58433203/114389912-e20f0680-9b95-11eb-9602-685fb4fe6bf9.png" width="300" />

## Additional info

There are still some icons missing (e.g. `faCube` next to a schema name in `Table Of Contents`) due to the way Font Awesome is implemented. This is a quick fix only for the caret icons