### PR TITLE
Fix sca vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "commit-msg": "node ./scripts/commit-msg-validate.js",
       "pre-commit": "lint-staged"
     }
   },

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "**/*"
   ],
   "scripts": {
+    "husky-run": "node ./scripts/husky-run-compat.js",
     "preinstall": "yarn install --ignore-scripts --ignore-engines || true",
     "build": "sl-scripts build --sourcemap && yarn build.styles",
     "build.styles": "yarn build.tw && mkdir -p dist/styles && cp -r src/styles/* dist/styles/",
@@ -213,7 +214,7 @@
     "picomatch": "2.3.2",
     "lodash.template": "4.18.0",
     "ip": "npm:neoip@2.1.0",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^4.1.2",
     "scss-tokenizer": "0.4.3",
     "browserslist": "4.23.0",
     "hosted-git-info": "2.8.9",
@@ -250,7 +251,8 @@
     "@stoplight/storybook-config/**/globule/minimatch": "3.1.4",
     "**/recursive-readdir/minimatch": "3.1.4",
     "**/globule/minimatch": "3.1.4",
-    "svgo": "^2.8.3"
+    "svgo": "^2.8.3",
+    "ip-address": "10.3.1"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/scripts/commit-msg-validate.js
+++ b/scripts/commit-msg-validate.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+const rawParams = process.env.HUSKY_GIT_PARAMS || '';
+const messageFile = rawParams.trim().split(/\s+/).find(Boolean);
+
+if (!messageFile) {
+  process.exit(0);
+}
+
+let message;
+try {
+  message = fs.readFileSync(messageFile, 'utf8');
+} catch (error) {
+  console.error(`commit-msg: unable to read commit message file: ${messageFile}`);
+  process.exit(1);
+}
+
+const firstLine = message.split(/\r?\n/)[0].trim();
+
+if (!firstLine) {
+  console.error('commit-msg: commit message cannot be empty');
+  process.exit(1);
+}
+
+const ignoredPrefixes = ['Merge ', 'Revert ', 'fixup!', 'squash!'];
+if (ignoredPrefixes.some(prefix => firstLine.startsWith(prefix))) {
+  process.exit(0);
+}
+
+const conventionalPattern = /^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._\/-]+\))?!?: .+/;
+
+if (!conventionalPattern.test(firstLine)) {
+  console.error('commit-msg: invalid commit message format');
+  console.error('Expected: <type>(optional-scope): <subject>');
+  console.error('Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test');
+  console.error(`Received: ${firstLine}`);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/scripts/husky-run-compat.js
+++ b/scripts/husky-run-compat.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+/*
+ * Compatibility bridge for legacy Husky v4 git hooks.
+ * Old hooks execute: yarn run --silent husky-run <hookName> <gitParams>
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const hookName = process.argv[2];
+const gitParams = process.argv.slice(3).join(' ');
+
+if (!hookName) {
+  process.exit(0);
+}
+
+const packageJsonPath = path.join(process.cwd(), 'package.json');
+if (!fs.existsSync(packageJsonPath)) {
+  process.exit(0);
+}
+
+let packageJson;
+try {
+  packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+} catch {
+  process.exit(0);
+}
+
+const hookCommand = packageJson?.husky?.hooks?.[hookName];
+if (!hookCommand) {
+  process.exit(0);
+}
+
+const result = spawnSync(hookCommand, {
+  stdio: 'inherit',
+  shell: true,
+  env: {
+    ...process.env,
+    HUSKY_GIT_PARAMS: gitParams,
+  },
+});
+
+if (typeof result.status === 'number') {
+  process.exit(result.status);
+}
+
+process.exit(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8864,10 +8864,10 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1, fast-uri@^3.1.4:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+fast-uri@^3.0.1, fast-uri@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-4.1.2.tgz#1e225af32fb0a178db8f14d7d9ba93ff24485694"
+  integrity sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==
 
 fastest-levenshtein@^1.0.16, fastest-levenshtein@^1.0.7:
   version "1.0.16"
@@ -10435,10 +10435,10 @@ invariant@^2.2.3, invariant@^2.2.4:
   dependencies:
     loose-envify "^1.0.0"
 
-ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
+ip-address@10.3.1, ip-address@^10.1.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.3.1.tgz#929f9629d1724f7e1b7485ce89752f3675336a10"
+  integrity sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==
 
 ip-regex@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
[STOP-6357](https://smartbear.atlassian.net/browse/STOP-6357) & [STOP-6361](https://smartbear.atlassian.net/browse/STOP-6361)
## Description
<!-- Describe your technical changes in detail. -->
*Summary*

The `ip-address` library (version 10.2.0) used in the `stoplightio/ui-kit` repository contains a vulnerability (CVE-2026-69192) where `Address4` incorrectly parses octets with leading zeros as decimal instead of octal. This creates a disagreement between the library and the underlying network stack — for example, `012.0.0.1` is classified as a public IP by the library but resolves to the private address `10.0.0.1` at the network level. Any SSRF filter built on `Address4` methods (`isPrivate()`, `isLoopback()`, `isInSubnet()`, etc.) is therefore bypassable, allowing internal targets to be reached by attackers supplying octal-ambiguous addresses.

*Remediation*

Upgrade `ip-address` from `10.2.0` to `10.3.1` or later in the `stoplightio/ui-kit` repository. The patched version rejects any octet with a leading zero, making `Address4.isValid('012.0.0.1')` return `false`. If an immediate upgrade is not possible, apply the following pre-parse guard before any address classification:

```js
if (host.split('.').some((octet) => /^0\d/.test(octet))) throw new Error('ambiguous address');
```

Note: after upgrading, any legacy system supplying zero-padded addresses (e.g., `010.010.010.010`) must strip leading zeros before parsing.

*Summary*

CVE-2026-18446 affects `fast-uri` v3.1.4 (found in `/yarn.lock` of the `stoplightio/ui-kit` repository, `main` branch). The vulnerability stems from a parsing discrepancy between `fast-uri` and Node.js's native WHATWG URL parser: `fast-uri` fails to recognize backslash-based URI authority introducers (`
`, `/\`, `\/`), treating them as path components, while Node.js treats backslashes as equivalent to forward slashes for special schemes. Applications that rely on `fast-uri` for host-based policy enforcement (SSRF filtering, allowlists, redirect validation) before passing the same URL to Node's `fetch()` or HTTP clients can be bypassed, potentially routing requests to unintended hosts. The finding is rated High severity (CVSS 7.5) and was first detected on 2026-08-05.

*Remediation*

Upgrade `fast-uri` to one of the patched versions: *v4.1.2*, *v3.1.5*, or *v2.4.4*. No workarounds are available — upgrading is the only fix. Update the dependency in `yarn.lock` (and the corresponding `package.json` entry) within the `stoplightio/ui-kit` repository on the `main` branch, then re-run `yarn install` to lock the patched version. Validate the update via the Dependabot advisory [here](hxxps://github . com/stoplightio/ui-kit/security/dependabot/336).

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Tested it locally.

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->
<img width="800" height="307" alt="Screenshot 2026-08-12 at 1 07 05 PM" src="https://github.com/user-attachments/assets/2164b4d7-319a-4166-9715-4e12ac12f49f" />
<img width="1354" height="392" alt="Screenshot 2026-08-12 at 1 07 40 PM" src="https://github.com/user-attachments/assets/4325defa-f02c-4bfc-8c1b-4da46dc9078f" />
<img width="1328" height="423" alt="Screenshot 2026-08-12 at 1 08 19 PM" src="https://github.com/user-attachments/assets/b1a479b8-26db-4ab8-8f39-28f11f9d7260" />
<img width="1279" height="428" alt="Screenshot 2026-08-12 at 1 08 45 PM" src="https://github.com/user-attachments/assets/8ade2de2-fcff-48c5-a0ce-18e915fedd11" />


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->


[STOP-6357]: https://smartbear.atlassian.net/browse/STOP-6357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STOP-6361]: https://smartbear.atlassian.net/browse/STOP-6361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ