### PR TITLE
chore(deps): updated nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@types/node": "12.12.62",
     "@types/lodash": "4.14.149",
     "postcss": "^8.5.23",
+    "nanoid": "^3.3.18",
     "@types/babel__traverse": "^7.17.0",
     "@types/react": "~16.9.34",
     "undici": "^6.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12825,10 +12825,10 @@ nan@^2.12.1, nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
   integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.17, nanoid@^3.3.18:
+  version "3.3.18"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Fix high-severity DoS vulnerability in nanoid (CVE-2026-67213)
Summary
Pins the transitive nanoid dependency to ^3.3.18 via a resolutions entry to remediate [CVE-2026-67213](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (GHSA-2v37-7h3g-55p8).

Vulnerability details
Package: nanoid
Affected version: 3.3.16 (transitive, via postcss)
Patched version: 3.3.18
CVE: CVE-2026-67213
Severity: High (CVSS 8.2)
CWE-835: Loop with Unreachable Exit Condition (Infinite Loop)
customAlphabet and customRandom in affected nanoid versions enter an infinite loop when called with size = 0. Any code path that passes an unvalidated, attacker-controlled size of 0 to these functions hangs the calling thread, resulting in a denial-of-service condition.

Changes
[package.json](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): added "nanoid": "^3.3.18" under resolutions to force all transitive consumers (currently pulled in via postcss) onto the patched version.
[yarn.lock](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): regenerated via yarn install so nanoid now resolves to 3.3.18 instead of 3.3.16.
Verification
Confirmed [yarn.lock](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) now contains a single merged entry:

Risk / impact
nanoid is not used directly by this library; it's only a transitive dependency of postcss. The version bump (3.3.16 → 3.3.18) is a patch-level change with no known breaking API changes.
No application code changes required.